### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - '*[v]?[0-9]+.[0-9]+.[0-9]+'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     uses: ./.github/workflows/ci.yml


### PR DESCRIPTION
- 4e4544b **ci: limit concurrent CD workflows for the same commit**
  Since `cargo workspaces` will publish all unpublished crates, we don't
  need to run the CD workflow twice for the same commit SHA, regardless if
  more than one tag was created for it

- 5504ac4 **ci: add pull-request workflow**
  Try to enforce linear history + signed commits for the `main` branch by
  leveraging a GitHub action to perform fast-forward merges.
