### PR TITLE
ci: use personal access token for fast-forward workflow

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Fast forwarding
         uses: sequoia-pgp/fast-forward@v1
         with:
+          github_token: ${{ secrets.RELEASE_PLEASE }}
           merge: true
           # To reduce the workflow's verbosity, use 'on-error'
           # to only post a comment when an error occurs, or 'never' to


### PR DESCRIPTION
It seems that fast-forwards by the workflow with the standard
GITHUB_TOKEN don't trigger actions. Try using the same token as
release-please in order to trigger them
