### PR TITLE
feat(af-ptbuilder): conversions from/to a Sui PTB

### DIFF
--- a/crates/af-ptbuilder/Cargo.toml
+++ b/crates/af-ptbuilder/Cargo.toml
@@ -34,5 +34,16 @@ af-sui-types = { version = "0.7.0", path = "../af-sui-types" }
 
 
 [dev-dependencies]
-eyre = "0.6"
-rand = "0.8"
+clap          = { version = "4", features = ["derive"] }
+eyre          = "0.6"
+proptest      = "1"
+rand          = "0.8"
+serde_json    = "1"
+serde_with    = "3"
+sui-sdk-types = { version = "0.0.2", features = ["proptest"] }
+test-strategy = "0.4"
+
+
+[[example]]
+name = "ptbuilder-serde"
+path = "./examples/builder_serde.rs"

--- a/crates/af-ptbuilder/examples/builder_serde.rs
+++ b/crates/af-ptbuilder/examples/builder_serde.rs
@@ -1,0 +1,61 @@
+use af_ptbuilder::ProgrammableTransactionBuilder;
+use af_sui_types::encoding::Base64Bcs;
+use af_sui_types::ProgrammableTransaction;
+use clap::Parser;
+use serde_with::{serde_as, TryFromInto};
+
+const DEFAULT_PTB_BASE64: &str = r#"{
+"builder": "IwEAbvkm9unJ4JcOxhlrOw08M/xKb7DO+30cR25/gkfz/SraOfkTAAAAACDbg3ct3L8dmGhGzB1wwugYjNTEsOQAdKM0WMJ++j/QpAEBSb1AzHiAvTWEZRFhV/AnHCXSM2G5Tqzpol3CAZtEm/yNnOcPAAAAAAEBAS4mgWYWJE/pUu+SRFPTRo7Xat3qr1hzyvCXC6mysycimk/bDwAAAAAAAQHRCzhcgsuh9nOnRW68l+CUnrTKpxtKGpv+TVk4TnmieZxP2w8AAAAAAAEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYBAAAAAAAAAAAAEDD9FAAAAAAAdn65xP////8AECn9FAAAAAAAmpm5xP////8AEA/9FAAAAAAANTG7xP////8AEB/9FAAAAAAATHxTOwAAAAAAEBn9FAAAAAAAekJUOwAAAAAAEB39FAAAAAAAzlBVOwAAAAAAEAz9FAAAAAAA465TOwAAAAAAEBv9FAAAAAAAMrlTOwAAAAAAEBj9FAAAAAAAMdtSOwAAAAAAAQEAAQAACAAAAAAAAAAAAAg/QUg7AAAAAAAIgoYIAAAAAAAACPYnRjsAAAAAAAgRxA4AAAAAAAAIANNPOwAAAAAACAqUCQAAAAAAAAgWz0w7AAAAAAAIj7MJAAAAAAAACAlDSTsAAAAAAAhxEA8AAAAAAAAIDxROOwAAAAAACAdeDAAAAAAAAAjS00E7AAAAAAAIPNYMAAAAAAAACPeUPTsAAAAAAAjY0gwAAAAAAAAIgYdAOwAAAAAACCw1CwAAAAAADgUBAwkBBQABBgABBwABCAABCQABCgABCwABDAABDQAAlyUVWnDPLSJBuMwvqDdoCWiTEsq7Ssqlylukfq9NYR8JaW50ZXJmYWNlDWNhbmNlbF9vcmRlcnMBB0VwSTcfW13CvahXu4BMpuk8WjyuFjbQzRe7a2Bw0ZRYBHVzZGMEVVNEQwADAQEAAQAAAgAAAJclFVpwzy0iQbjML6g3aAlokxLKu0rKpcpbpH6vTWEfCWludGVyZmFjZQ1zdGFydF9zZXNzaW9uAQdFcEk3H1tdwr2oV7uATKbpPFo8rhY20M0Xu2tgcNGUWAR1c2RjBFVTREMABQEBAAEAAAECAAEDAAEEAACXJRVacM8tIkG4zC+oN2gJaJMSyrtKyqXKW6R+r01hHwlpbnRlcmZhY2URcGxhY2VfbGltaXRfb3JkZXIBB0VwSTcfW13CvahXu4BMpuk8WjyuFjbQzRe7a2Bw0ZRYBHVzZGMEVVNEQwAFAgIAAQ4AARIAAREAARAAAJclFVpwzy0iQbjML6g3aAlokxLKu0rKpcpbpH6vTWEfCWludGVyZmFjZRFwbGFjZV9saW1pdF9vcmRlcgEHRXBJNx9bXcK9qFe7gEym6TxaPK4WNtDNF7trYHDRlFgEdXNkYwRVU0RDAAUCAgABDgABFAABEwABEAAAlyUVWnDPLSJBuMwvqDdoCWiTEsq7Ssqlylukfq9NYR8JaW50ZXJmYWNlEXBsYWNlX2xpbWl0X29yZGVyAQdFcEk3H1tdwr2oV7uATKbpPFo8rhY20M0Xu2tgcNGUWAR1c2RjBFVTREMABQICAAEOAAEWAAEVAAEQAACXJRVacM8tIkG4zC+oN2gJaJMSyrtKyqXKW6R+r01hHwlpbnRlcmZhY2URcGxhY2VfbGltaXRfb3JkZXIBB0VwSTcfW13CvahXu4BMpuk8WjyuFjbQzRe7a2Bw0ZRYBHVzZGMEVVNEQwAFAgIAAQ4AARgAARcAARAAAJclFVpwzy0iQbjML6g3aAlokxLKu0rKpcpbpH6vTWEfCWludGVyZmFjZRFwbGFjZV9saW1pdF9vcmRlcgEHRXBJNx9bXcK9qFe7gEym6TxaPK4WNtDNF7trYHDRlFgEdXNkYwRVU0RDAAUCAgABDgABGgABGQABEAAAlyUVWnDPLSJBuMwvqDdoCWiTEsq7Ssqlylukfq9NYR8JaW50ZXJmYWNlEXBsYWNlX2xpbWl0X29yZGVyAQdFcEk3H1tdwr2oV7uATKbpPFo8rhY20M0Xu2tgcNGUWAR1c2RjBFVTREMABQICAAEOAAEcAAEbAAEQAACXJRVacM8tIkG4zC+oN2gJaJMSyrtKyqXKW6R+r01hHwlpbnRlcmZhY2URcGxhY2VfbGltaXRfb3JkZXIBB0VwSTcfW13CvahXu4BMpuk8WjyuFjbQzRe7a2Bw0ZRYBHVzZGMEVVNEQwAFAgIAAQ8AAR4AAR0AARAAAJclFVpwzy0iQbjML6g3aAlokxLKu0rKpcpbpH6vTWEfCWludGVyZmFjZRFwbGFjZV9saW1pdF9vcmRlcgEHRXBJNx9bXcK9qFe7gEym6TxaPK4WNtDNF7trYHDRlFgEdXNkYwRVU0RDAAUCAgABDwABIAABHwABEAAAlyUVWnDPLSJBuMwvqDdoCWiTEsq7Ssqlylukfq9NYR8JaW50ZXJmYWNlEXBsYWNlX2xpbWl0X29yZGVyAQdFcEk3H1tdwr2oV7uATKbpPFo8rhY20M0Xu2tgcNGUWAR1c2RjBFVTREMABQICAAEPAAEiAAEhAAEQAACXJRVacM8tIkG4zC+oN2gJaJMSyrtKyqXKW6R+r01hHwlpbnRlcmZhY2ULZW5kX3Nlc3Npb24BB0VwSTcfW13CvahXu4BMpuk8WjyuFjbQzRe7a2Bw0ZRYBHVzZGMEVVNEQwABAgIAAJclFVpwzy0iQbjML6g3aAlokxLKu0rKpcpbpH6vTWEfCWludGVyZmFjZRRzaGFyZV9jbGVhcmluZ19ob3VzZQEHRXBJNx9bXcK9qFe7gEym6TxaPK4WNtDNF7trYHDRlFgEdXNkYwRVU0RDAAEDDAAAAA=="
+}"#;
+
+/// Showcases how one can leverage the conversions to/from `ProgrammableTransaction` to
+/// de/serialize the builder.
+#[derive(Parser)]
+struct Cli {
+    #[arg(long, value_parser = parse_payload, default_value = DEFAULT_PTB_BASE64)]
+    payload: Payload,
+}
+
+/// Example of a JSON payload we might wanna transmit.
+#[serde_as]
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
+pub struct Payload {
+    #[serde_as(as = "TryFromInto<Base64Ptb>")]
+    pub builder: ProgrammableTransactionBuilder,
+}
+
+/// Intermediate layer to leverage [`ProgrammableTransaction`]'s serialization to base64.
+#[serde_as]
+#[derive(serde::Deserialize, serde::Serialize)]
+struct Base64Ptb(#[serde_as(as = "Base64Bcs")] ProgrammableTransaction);
+
+/// For [`TryFromInto`]
+impl From<ProgrammableTransactionBuilder> for Base64Ptb {
+    fn from(value: ProgrammableTransactionBuilder) -> Self {
+        Self(value.into())
+    }
+}
+
+/// For [`TryFromInto`]
+impl TryFrom<Base64Ptb> for ProgrammableTransactionBuilder {
+    type Error = <Self as TryFrom<ProgrammableTransaction>>::Error;
+
+    fn try_from(value: Base64Ptb) -> Result<Self, Self::Error> {
+        value.0.try_into()
+    }
+}
+
+/// For [`clap`] only
+fn parse_payload(s: &str) -> eyre::Result<Payload> {
+    Ok(serde_json::from_str(s)?)
+}
+
+fn main() -> eyre::Result<()> {
+    let Cli { payload } = Cli::parse();
+
+    println!("{:#?}", payload.builder);
+
+    println!("{}", serde_json::to_string_pretty(&payload)?);
+
+    Ok(())
+}

--- a/crates/af-ptbuilder/proptest-regressions/tests.txt
+++ b/crates/af-ptbuilder/proptest-regressions/tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 89df0dc2fead116a126f6c8c6f223f2c55f78d8d6c1ec42e5b36ba2ca44ab3e0 # shrinks to input = _PtbConversionArgs { ptb: ProgrammableTransaction { inputs: [Pure { value: [] }], commands: [] } }

--- a/crates/af-ptbuilder/src/tests.rs
+++ b/crates/af-ptbuilder/src/tests.rs
@@ -1,0 +1,10 @@
+use test_strategy::proptest;
+
+use super::*;
+
+#[proptest]
+fn ptb_conversion(ptb: ProgrammableTransaction) {
+    let builder: ProgrammableTransactionBuilder = ptb.clone().try_into().expect("into builder");
+    let ptb_: ProgrammableTransaction = builder.into();
+    assert_eq!(ptb, ptb_);
+}


### PR DESCRIPTION
Adds
- conversions from/to `ProgrammableTransaction` to
  `ProgrammableTransactionBuilder`
- `#[derive(Clone, Debug)]` for `ProgrammableTransactionBuilder`

To ensure this is working, a proptest and an example were added.
