### PR TITLE
feat(af-sui-types): export `TransactionFromBase64Error`

### DIFF
--- a/crates/af-sui-types/src/lib.rs
+++ b/crates/af-sui-types/src/lib.rs
@@ -114,6 +114,7 @@ pub use self::sui::transaction::{
     TransactionData,
     TransactionDataAPI,
     TransactionDataV1,
+    TransactionFromBase64Error,
 };
 
 // =============================================================================

--- a/crates/af-sui-types/src/sui/transaction/mod.rs
+++ b/crates/af-sui-types/src/sui/transaction/mod.rs
@@ -7,6 +7,7 @@ pub use self::data::{
     TransactionData,
     TransactionDataAPI,
     TransactionDataV1,
+    TransactionFromBase64Error,
 };
 
 /// Temporarily here just to enable [`CheckpointTransaction`] serde.


### PR DESCRIPTION
This was previously hidden, so dependents couldn't wrap it or match
against its variants
