### PR TITLE
`graphql-extract` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,5 @@
 [workspace]
-members = [
-  "crates/af-faucet",
-  "crates/af-iperps",
-  "crates/af-keys",
-  "crates/af-move-type",
-  "crates/af-move-type-derive",
-  "crates/af-oracle",
-  "crates/af-ptbuilder",
-  "crates/af-pyth-wrapper",
-  "crates/af-sui-pkg-sdk",
-  "crates/af-sui-types",
-  "crates/af-utilities",
-  "crates/move-stdlib-sdk",
-  "crates/pyth-hermes-client",
-  "crates/pyth-sui-sdk",
-  "crates/sui-framework-sdk",
-  "crates/sui-gql-client",
-  "crates/sui-gql-schema",
-  "crates/sui-jsonrpc",
-  "crates/wormhole-sui-sdk",
-]
+members  = ["crates/*"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/graphql-extract/Cargo.toml
+++ b/crates/graphql-extract/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+autotests   = false
+description = "Macro to extract data from deeply nested types representing GraphQL results"
+name        = "graphql-extract"
+version     = "0.0.1"
+
+authors.workspace    = true
+categories.workspace = true
+edition.workspace    = true
+license.workspace    = true
+repository.workspace = true
+
+[package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="-Zunstable-options --generate-link-to-definition" RUSTC_BOOTSTRAP=1 cargo +nightly doc --all-features --no-deps --open
+all-features = true
+rustdoc-args = [
+  # Generate links to definition in rustdoc source code pages
+  # https://github.com/rust-lang/rust/pull/84176
+  "--generate-link-to-definition",
+  "-Zunstable-options",
+]
+
+[lib]
+proc-macro = true
+
+[lints]
+workspace = true
+
+[dependencies]
+derive-syn-parse = "0.2"
+proc-macro2      = "1"
+quote            = "1"
+syn              = { version = "2", features = ["full"] }
+
+[dev-dependencies]
+insta    = "1"
+trybuild = { version = "1", features = ["diff"] }
+
+[[test]]
+name = "trybuild"
+path = "tests/trybuild.rs"
+
+[[test]]
+name = "errors"
+path = "tests/errors.rs"
+

--- a/crates/graphql-extract/README.md
+++ b/crates/graphql-extract/README.md
@@ -1,0 +1,20 @@
+<!-- cargo-rdme start -->
+
+Macro to extract data from deeply nested types representing GraphQL results
+
+# Suggested workflow
+
+1. Generate query types using [cynic] and its [generator]
+1. Use [insta] to define an inline snapshot test so that the query string is visible in the
+   module that defines the query types
+1. Define an `extract` function that takes the root query type and returns the data of interest
+1. Inside `extract`, use `extract!` as `extract!(data => { ... })`
+1. Inside the curly braces, past the query string from the snapshot test above
+1. Change all node names from `camelCase` to `snake_case`
+1. Add `?` after the nodes that are nullable
+1. Add `[]` after the nodes that are iterable
+
+[cynic]: https://cynic-rs.dev/
+[generator]: https://generator.cynic-rs.dev/
+
+<!-- cargo-rdme end -->

--- a/crates/graphql-extract/src/lib.rs
+++ b/crates/graphql-extract/src/lib.rs
@@ -1,0 +1,278 @@
+//! Macro to extract data from deeply nested types representing GraphQL results
+//!
+//! # Suggested workflow
+//!
+//! 1. Generate query types using [cynic] and its [generator]
+//! 1. Use [insta] to define an inline snapshot test so that the query string is visible in the
+//!    module that defines the query types
+//! 1. Define an `extract` function that takes the root query type and returns the data of interest
+//! 1. Inside `extract`, use [`extract!`](crate::extract) as `extract!(data => { ... })`
+//! 1. Inside the curly braces, past the query string from the snapshot test above
+//! 1. Change all node names from `camelCase` to `snake_case`
+//! 1. Add `?` after the nodes that are nullable
+//! 1. Add `[]` after the nodes that are iterable
+//!
+//! [cynic]: https://cynic-rs.dev/
+//! [generator]: https://generator.cynic-rs.dev/
+
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens as _};
+use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned as _;
+use syn::token::{self, Brace};
+use syn::{braced, bracketed, parse_macro_input, parse_quote, Error, Ident, Token};
+
+/// See the top-level [`crate`] doc for a description.
+#[proc_macro]
+pub fn extract(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let root = parse_macro_input!(input as Root);
+    let stmt = root.generate_extract();
+    stmt.into()
+}
+
+struct Root {
+    expr: syn::Expr,
+    nested: Nested,
+}
+
+struct Node {
+    ident: Ident,
+    optional: bool,
+    iterable: bool,
+    nested: Option<Nested>,
+}
+
+enum Nested {
+    Nodes(Vec<Node>),
+    Variant(Variant),
+}
+
+struct Variant {
+    path: syn::Path,
+    nodes: Vec<Node>,
+}
+
+//=================================================================================================
+// Parsing
+//=================================================================================================
+
+impl Parse for Root {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let expr = input.parse()?;
+        let _: Token![=>] = input.parse()?;
+        let nested = input.parse()?;
+        Ok(Self { expr, nested })
+    }
+}
+
+impl Parse for Node {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut self_ = Self {
+            ident: input.parse()?,
+            optional: false,
+            iterable: false,
+            nested: None,
+        };
+
+        while !input.is_empty() {
+            let lookahead = input.lookahead1();
+            if lookahead.peek(Ident) {
+                break; // There's another field to be parsed
+            } else if lookahead.peek(Token![?]) {
+                let question: Token![?] = input.parse()?;
+                if self_.optional {
+                    return Err(Error::new_spanned(
+                        question,
+                        "Can't have two `?` for the same node",
+                    ));
+                }
+                self_.optional = true;
+            } else if lookahead.peek(token::Bracket) {
+                let content;
+                let bracket = bracketed!(content in input);
+                if self_.iterable {
+                    return Err(Error::new(
+                        bracket.span.span(),
+                        "Can't have two `[]` for the same node",
+                    ));
+                }
+                if !content.is_empty() {
+                    return Err(Error::new(
+                        bracket.span.span(),
+                        "Only empty brackets allowed",
+                    ));
+                }
+                self_.iterable = true;
+            } else if lookahead.peek(token::Brace) {
+                let nested = input.parse()?;
+                self_.nested = Some(nested);
+                break; // Everything after the closing brace is ignored
+            } else {
+                return Err(lookahead.error());
+            }
+        }
+
+        Ok(self_)
+    }
+}
+
+impl Node {
+    fn within_braces(brace: Brace, content: ParseStream) -> syn::Result<Vec<Self>> {
+        let mut nodes = vec![];
+        while !content.is_empty() {
+            let lookahead = content.lookahead1();
+            if lookahead.peek(Token![...]) {
+                return Err(Error::new(
+                    brace.span.span(),
+                    "Nodes can't be mixed with '... on Variant' matches",
+                ));
+            }
+            nodes.push(content.parse()?);
+        }
+        if nodes.is_empty() {
+            return Err(Error::new(
+                brace.span.span(),
+                "Empty braces; must have at least one node",
+            ));
+        }
+        Ok(nodes)
+    }
+}
+
+impl Parse for Nested {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        let brace = braced!(content in input);
+
+        let lookahead = content.lookahead1();
+        Ok(if lookahead.peek(Token![...]) {
+            let var = Self::Variant(content.parse()?);
+            if !content.is_empty() {
+                return Err(Error::new(
+                    brace.span.span(),
+                    "Only a single '... on Variant' match is supported within the same braces",
+                ));
+            }
+            var
+        } else {
+            Self::Nodes(Node::within_braces(brace, &content)?)
+        })
+    }
+}
+
+impl Parse for Variant {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        input.parse::<Token![...]>()?;
+        let on: Ident = input.parse()?;
+        if on != "on" {
+            return Err(Error::new(on.span(), "Expected 'on'"));
+        }
+        let path = input.parse()?;
+        let content;
+        let brace = braced!(content in input);
+        Ok(Self {
+            path,
+            nodes: Node::within_braces(brace, &content)?,
+        })
+    }
+}
+
+//=================================================================================================
+// Generation
+//=================================================================================================
+
+impl Root {
+    fn generate_extract(self) -> TokenStream {
+        let Self { expr, nested, .. } = self;
+        let data = Ident::new("data", Span::mixed_site());
+        let err = data.to_string() + " is null";
+        let (pats, tokens): (Vec<_>, Vec<_>) =
+            nested.generate_extract(data.clone(), data.to_string());
+        quote! {
+            let #data = ( #expr ).ok_or(#err)?;
+            let ( #(#pats),* ) = {
+                #(#tokens)*
+                ( #(#pats),* )
+            };
+        }
+    }
+}
+
+impl Node {
+    fn generate_extract(self, data: Ident, path: String) -> (syn::Pat, TokenStream) {
+        let Self {
+            ident,
+            optional,
+            iterable,
+            nested,
+        } = self;
+
+        let path = path + " -> " + ident.to_string().as_str();
+
+        let assign = if optional {
+            let err = path.clone() + " is null";
+            quote!(let #ident = #data.#ident.ok_or(#err)?;)
+        } else {
+            quote!(let #ident = #data.#ident;)
+        };
+
+        let Some(inner) = nested else {
+            return (parse_quote!(#ident), assign);
+        };
+
+        let (pats, tokens) = inner.generate_extract(ident.clone(), path);
+        let (pat, tokens_);
+        // TODO: consider
+        // - verifying that no nested `[]` exist
+        // - detecting any `?` in the subtree and setting the return type accordingly
+        if iterable {
+            pat = parse_quote!(#ident);
+            tokens_ = quote! {
+                #assign
+                let #ident = #ident.into_iter().map(|#ident| -> Result<_, &'static str> {
+                    #(#tokens)*
+                    Ok(( #(#pats),* ))
+                });
+            };
+        } else {
+            pat = parse_quote!( (#(#pats),*) );
+            tokens_ = quote! {
+                #assign
+                let ( #(#pats),* ) = {
+                    #(#tokens)*
+                    ( #(#pats),* )
+                };
+            };
+        }
+        (pat, tokens_)
+    }
+}
+
+impl Nested {
+    fn generate_extract(self, data: Ident, path: String) -> (Vec<syn::Pat>, Vec<TokenStream>) {
+        match self {
+            Self::Nodes(nodes) => nodes
+                .into_iter()
+                .map(|n| n.generate_extract(data.clone(), path.clone()))
+                .unzip(),
+            Self::Variant(Variant { path: var, nodes }) => {
+                let path = path + " ... on " + var.to_token_stream().to_string().as_str();
+                let err = path.clone() + " is null";
+                let val = Ident::new("val", Span::mixed_site());
+                let assign = quote! {
+                    let #var(#val) = #data else {
+                        return Err(#err);
+                    };
+                };
+
+                let mut tokens_ = vec![assign];
+                let (pats, tokens): (Vec<_>, Vec<_>) = nodes
+                    .into_iter()
+                    .map(|n| n.generate_extract(val.clone(), path.clone()))
+                    .unzip();
+                tokens_.extend(tokens);
+                (pats, tokens_)
+            }
+        }
+    }
+}

--- a/crates/graphql-extract/tests/build/01.rs
+++ b/crates/graphql-extract/tests/build/01.rs
@@ -1,0 +1,62 @@
+struct Query {
+    address: Option<Address2>,
+    object: Option<Object>,
+}
+
+struct Address2 {
+    address: String,
+}
+
+struct Object {
+    version: u64,
+    dynamic_field: Option<DynamicField>,
+    dynamic_fields: DynamicFieldConnection,
+}
+
+struct DynamicFieldConnection {
+    nodes: Vec<DynamicField>,
+}
+
+struct DynamicField {
+    value: Option<DynamicFieldValue>,
+}
+
+enum DynamicFieldValue {
+    MoveValue(MoveValue),
+    Unknown,
+}
+
+struct MoveValue {
+    type_: MoveType,
+    bcs: String,
+}
+
+struct MoveType {
+    repr: String,
+}
+
+type Item = Result<(MoveType, String), &'static str>;
+
+fn extract(data: Option<Query>) -> Result<(u64, impl Iterator<Item = Item>), &'static str> {
+    use graphql_extract::extract;
+    use DynamicFieldValue::MoveValue;
+
+    extract!(data => {
+        object? {
+            version
+            dynamic_fields {
+                nodes[] {
+                    value? {
+                        ... on MoveValue {
+                            type_
+                            bcs
+                        }
+                    }
+                }
+            }
+        }
+    });
+    Ok((version, nodes))
+}
+
+fn main() {}

--- a/crates/graphql-extract/tests/build/02.rs
+++ b/crates/graphql-extract/tests/build/02.rs
@@ -1,0 +1,62 @@
+struct Query {
+    address: Option<Address2>,
+    object: Option<Object>,
+}
+
+struct Address2 {
+    address: String,
+}
+
+struct Object {
+    version: u64,
+    dynamic_field: Option<DynamicField>,
+    dynamic_fields: DynamicFieldConnection,
+}
+
+struct DynamicFieldConnection {
+    nodes: Vec<DynamicField>,
+}
+
+struct DynamicField {
+    value: Option<DynamicFieldValue>,
+}
+
+enum DynamicFieldValue {
+    MoveValue(MoveValue),
+    Unknown,
+}
+
+struct MoveValue {
+    type_: MoveType,
+    bcs: String,
+}
+
+struct MoveType {
+    repr: String,
+}
+
+type Item = Result<(MoveType, String), &'static str>;
+
+fn extract(data: Option<Query>) -> Result<(u64, impl Iterator<Item = Item>), &'static str> {
+    use graphql_extract::extract;
+    use DynamicFieldValue::MoveValue;
+
+    extract!(data => {
+        object? {
+            version
+            dynamic_fields {
+                nodes[][] {
+                    value? {
+                        ... on MoveValue {
+                            type_
+                            bcs
+                        }
+                    }
+                }
+            }
+        }
+    });
+    Ok((version, nodes))
+}
+
+fn main() {}

--- a/crates/graphql-extract/tests/build/02.stderr
+++ b/crates/graphql-extract/tests/build/02.stderr
@@ -1,0 +1,25 @@
+error: Can't have two `[]` for the same node
+  --> tests/build/02.rs:48:24
+   |
+48 |                 nodes[][] {
+   |                        ^^
+
+error[E0425]: cannot find value `version` in this scope
+  --> tests/build/02.rs:59:9
+   |
+59 |     Ok((version, nodes))
+   |         ^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `nodes` in this scope
+  --> tests/build/02.rs:59:18
+   |
+59 |     Ok((version, nodes))
+   |                  ^^^^^ not found in this scope
+
+warning: unused import: `DynamicFieldValue::MoveValue`
+  --> tests/build/02.rs:42:9
+   |
+42 |     use DynamicFieldValue::MoveValue;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unused_imports)]` on by default

--- a/crates/graphql-extract/tests/build/03.rs
+++ b/crates/graphql-extract/tests/build/03.rs
@@ -1,0 +1,21 @@
+struct Query {
+    address: Option<Address2>,
+}
+
+struct Address2 {
+    address: String,
+}
+
+type Item = Result<(MoveType, String), &'static str>;
+
+fn extract(data: Option<Query>) -> Result<(u64, impl Iterator<Item = Item>), &'static str> {
+    use graphql_extract::extract;
+    use DynamicFieldValue::MoveValue;
+
+    extract!(data => {
+        address??
+    });
+    Ok((version, nodes))
+}
+
+fn main() {}

--- a/crates/graphql-extract/tests/build/03.stderr
+++ b/crates/graphql-extract/tests/build/03.stderr
@@ -1,0 +1,34 @@
+error: Can't have two `?` for the same node
+  --> tests/build/03.rs:16:17
+   |
+16 |         address??
+   |                 ^
+
+error[E0432]: unresolved import `DynamicFieldValue`
+  --> tests/build/03.rs:13:9
+   |
+13 |     use DynamicFieldValue::MoveValue;
+   |         ^^^^^^^^^^^^^^^^^ use of undeclared type `DynamicFieldValue`
+
+error[E0412]: cannot find type `MoveType` in this scope
+ --> tests/build/03.rs:9:21
+  |
+9 | type Item = Result<(MoveType, String), &'static str>;
+  |                     ^^^^^^^^ not found in this scope
+  |
+help: you might be missing a type parameter
+  |
+9 | type Item<MoveType> = Result<(MoveType, String), &'static str>;
+  |          ++++++++++
+
+error[E0425]: cannot find value `version` in this scope
+  --> tests/build/03.rs:18:9
+   |
+18 |     Ok((version, nodes))
+   |         ^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `nodes` in this scope
+  --> tests/build/03.rs:18:18
+   |
+18 |     Ok((version, nodes))
+   |                  ^^^^^ not found in this scope

--- a/crates/graphql-extract/tests/build/04.rs
+++ b/crates/graphql-extract/tests/build/04.rs
@@ -1,0 +1,21 @@
+struct Query {
+    address: Option<Address2>,
+}
+
+struct Address2 {
+    address: String,
+}
+
+type Item = Result<(MoveType, String), &'static str>;
+
+fn extract(data: Option<Query>) -> Result<(u64, impl Iterator<Item = Item>), &'static str> {
+    use graphql_extract::extract;
+    use DynamicFieldValue::MoveValue;
+
+    extract!(data => {
+        address? {}
+    });
+    Ok((version, nodes))
+}
+
+fn main() {}

--- a/crates/graphql-extract/tests/build/04.stderr
+++ b/crates/graphql-extract/tests/build/04.stderr
@@ -1,0 +1,34 @@
+error: Empty braces; must have at least one node
+  --> tests/build/04.rs:16:18
+   |
+16 |         address? {}
+   |                  ^^
+
+error[E0432]: unresolved import `DynamicFieldValue`
+  --> tests/build/04.rs:13:9
+   |
+13 |     use DynamicFieldValue::MoveValue;
+   |         ^^^^^^^^^^^^^^^^^ use of undeclared type `DynamicFieldValue`
+
+error[E0412]: cannot find type `MoveType` in this scope
+ --> tests/build/04.rs:9:21
+  |
+9 | type Item = Result<(MoveType, String), &'static str>;
+  |                     ^^^^^^^^ not found in this scope
+  |
+help: you might be missing a type parameter
+  |
+9 | type Item<MoveType> = Result<(MoveType, String), &'static str>;
+  |          ++++++++++
+
+error[E0425]: cannot find value `version` in this scope
+  --> tests/build/04.rs:18:9
+   |
+18 |     Ok((version, nodes))
+   |         ^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `nodes` in this scope
+  --> tests/build/04.rs:18:18
+   |
+18 |     Ok((version, nodes))
+   |                  ^^^^^ not found in this scope

--- a/crates/graphql-extract/tests/build/05.rs
+++ b/crates/graphql-extract/tests/build/05.rs
@@ -1,0 +1,20 @@
+struct Query {
+    address: Option<Address2>,
+}
+
+struct Address2 {
+    address: String,
+}
+
+type Item = Result<(MoveType, String), &'static str>;
+
+fn extract(data: Option<Query>) -> Result<(u64, impl Iterator<Item = Item>), &'static str> {
+    use graphql_extract::extract;
+    use DynamicFieldValue::MoveValue;
+
+    extract!(data => {
+    });
+    Ok((version, nodes))
+}
+
+fn main() {}

--- a/crates/graphql-extract/tests/build/05.stderr
+++ b/crates/graphql-extract/tests/build/05.stderr
@@ -1,0 +1,36 @@
+error: Empty braces; must have at least one node
+  --> tests/build/05.rs:15:22
+   |
+15 |       extract!(data => {
+   |  ______________________^
+16 | |     });
+   | |_____^
+
+error[E0432]: unresolved import `DynamicFieldValue`
+  --> tests/build/05.rs:13:9
+   |
+13 |     use DynamicFieldValue::MoveValue;
+   |         ^^^^^^^^^^^^^^^^^ use of undeclared type `DynamicFieldValue`
+
+error[E0412]: cannot find type `MoveType` in this scope
+ --> tests/build/05.rs:9:21
+  |
+9 | type Item = Result<(MoveType, String), &'static str>;
+  |                     ^^^^^^^^ not found in this scope
+  |
+help: you might be missing a type parameter
+  |
+9 | type Item<MoveType> = Result<(MoveType, String), &'static str>;
+  |          ++++++++++
+
+error[E0425]: cannot find value `version` in this scope
+  --> tests/build/05.rs:17:9
+   |
+17 |     Ok((version, nodes))
+   |         ^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `nodes` in this scope
+  --> tests/build/05.rs:17:18
+   |
+17 |     Ok((version, nodes))
+   |                  ^^^^^ not found in this scope

--- a/crates/graphql-extract/tests/build/06.rs
+++ b/crates/graphql-extract/tests/build/06.rs
@@ -1,0 +1,51 @@
+struct Query {
+    object: Option<Object>,
+}
+
+struct Object {
+    version: u64,
+    dynamic_field: Option<DynamicField>,
+}
+
+struct DynamicField {
+    value: Option<DynamicFieldValue>,
+}
+
+enum DynamicFieldValue {
+    MoveValue(MoveValue),
+    Unknown,
+}
+
+struct MoveValue {
+    type_: MoveType,
+    bcs: String,
+}
+
+struct MoveType {
+    repr: String,
+}
+
+type Item = Result<(MoveType, String), &'static str>;
+
+fn extract(data: Option<Query>) -> Result<(u64, impl Iterator<Item = Item>), &'static str> {
+    use graphql_extract::extract;
+    use DynamicFieldValue::MoveValue;
+
+    extract!(data => {
+        object? {
+            version
+            dynamic_field {
+                value? {
+                    node
+                    ... on MoveValue {
+                        type_
+                        bcs
+                    }
+                }
+            }
+        }
+    });
+    Ok((version, nodes))
+}
+
+fn main() {}

--- a/crates/graphql-extract/tests/build/06.stderr
+++ b/crates/graphql-extract/tests/build/06.stderr
@@ -1,0 +1,25 @@
+error: expected one of: identifier, `?`, square brackets, curly braces
+  --> tests/build/06.rs:40:21
+   |
+40 |                     ... on MoveValue {
+   |                     ^
+
+error[E0425]: cannot find value `version` in this scope
+  --> tests/build/06.rs:48:9
+   |
+48 |     Ok((version, nodes))
+   |         ^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `nodes` in this scope
+  --> tests/build/06.rs:48:18
+   |
+48 |     Ok((version, nodes))
+   |                  ^^^^^ not found in this scope
+
+warning: unused import: `DynamicFieldValue::MoveValue`
+  --> tests/build/06.rs:32:9
+   |
+32 |     use DynamicFieldValue::MoveValue;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unused_imports)]` on by default

--- a/crates/graphql-extract/tests/build/07.rs
+++ b/crates/graphql-extract/tests/build/07.rs
@@ -1,0 +1,51 @@
+struct Query {
+    object: Option<Object>,
+}
+
+struct Object {
+    version: u64,
+    dynamic_field: Option<DynamicField>,
+}
+
+struct DynamicField {
+    value: Option<DynamicFieldValue>,
+}
+
+enum DynamicFieldValue {
+    MoveValue(MoveValue),
+    Unknown,
+}
+
+struct MoveValue {
+    type_: MoveType,
+    bcs: String,
+}
+
+struct MoveType {
+    repr: String,
+}
+
+type Item = Result<(MoveType, String), &'static str>;
+
+fn extract(data: Option<Query>) -> Result<(u64, impl Iterator<Item = Item>), &'static str> {
+    use graphql_extract::extract;
+    use DynamicFieldValue::MoveValue;
+
+    extract!(data => {
+        object? {
+            version
+            dynamic_field {
+                value? {
+                    ... on MoveValue {
+                        type_
+                        bcs
+                    }
+                    node
+                }
+            }
+        }
+    });
+    Ok((version, nodes))
+}
+
+fn main() {}

--- a/crates/graphql-extract/tests/build/07.stderr
+++ b/crates/graphql-extract/tests/build/07.stderr
@@ -1,0 +1,32 @@
+error: Only a single '... on Variant' match is supported within the same braces
+  --> tests/build/07.rs:38:24
+   |
+38 |                   value? {
+   |  ________________________^
+39 | |                     ... on MoveValue {
+40 | |                         type_
+41 | |                         bcs
+42 | |                     }
+43 | |                     node
+44 | |                 }
+   | |_________________^
+
+error[E0425]: cannot find value `version` in this scope
+  --> tests/build/07.rs:48:9
+   |
+48 |     Ok((version, nodes))
+   |         ^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `nodes` in this scope
+  --> tests/build/07.rs:48:18
+   |
+48 |     Ok((version, nodes))
+   |                  ^^^^^ not found in this scope
+
+warning: unused import: `DynamicFieldValue::MoveValue`
+  --> tests/build/07.rs:32:9
+   |
+32 |     use DynamicFieldValue::MoveValue;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unused_imports)]` on by default

--- a/crates/graphql-extract/tests/errors.rs
+++ b/crates/graphql-extract/tests/errors.rs
@@ -1,0 +1,97 @@
+#![expect(dead_code, reason = "Dummy query types")]
+
+#[derive(Debug)]
+struct Query {
+    object: Option<Object>,
+}
+
+#[derive(Debug)]
+struct Object {
+    dynamic_field: Option<DynamicField>,
+}
+
+#[derive(Debug)]
+struct DynamicField {
+    value: Option<DynamicFieldValue>,
+}
+
+#[derive(Debug)]
+enum DynamicFieldValue {
+    MoveValue(MoveValue),
+    Unknown,
+}
+
+#[derive(Debug)]
+struct MoveValue {
+    type_: MoveType,
+    bcs: Option<String>,
+}
+
+#[derive(Debug)]
+struct MoveType {
+    repr: String,
+}
+
+fn extract(data: Option<Query>) -> Result<(MoveType, String), &'static str> {
+    use graphql_extract::extract;
+    use DynamicFieldValue::MoveValue;
+
+    extract!(data => {
+        object? {
+            dynamic_field? {
+                value? {
+                    ... on MoveValue {
+                        type_
+                        bcs?
+                    }
+                }
+            }
+        }
+    });
+    Ok((type_, bcs))
+}
+
+#[test]
+fn missing_value() {
+    let data = Some(Query {
+        object: Some(Object {
+            dynamic_field: Some(DynamicField { value: None }),
+        }),
+    });
+
+    let err = extract(data).expect_err("Not Ok");
+    insta::assert_snapshot!(err, @"data -> object -> dynamic_field -> value is null");
+}
+
+#[test]
+fn missing_bcs() {
+    let data = Some(Query {
+        object: Some(Object {
+            dynamic_field: Some(DynamicField {
+                value: Some(DynamicFieldValue::MoveValue(MoveValue {
+                    type_: MoveType {
+                        repr: "type_name".into(),
+                    },
+                    bcs: None,
+                })),
+            }),
+        }),
+    });
+
+    let err = extract(data).expect_err("Not Ok");
+    insta::assert_snapshot!(err, @"data -> object -> dynamic_field -> value ... on MoveValue -> bcs is null");
+}
+
+#[test]
+fn wrong_variant() {
+    let data = Some(Query {
+        object: Some(Object {
+            dynamic_field: Some(DynamicField {
+                value: Some(DynamicFieldValue::Unknown),
+            }),
+        }),
+    });
+
+    let err = extract(data).expect_err("Not Ok");
+    insta::assert_snapshot!(err, @"data -> object -> dynamic_field -> value ... on MoveValue is null");
+}

--- a/crates/graphql-extract/tests/trybuild.rs
+++ b/crates/graphql-extract/tests/trybuild.rs
@@ -1,0 +1,11 @@
+#[test]
+fn trybuild() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/build/01.rs");
+    t.compile_fail("tests/build/02.rs");
+    t.compile_fail("tests/build/03.rs");
+    t.compile_fail("tests/build/04.rs");
+    t.compile_fail("tests/build/05.rs");
+    t.compile_fail("tests/build/06.rs");
+    t.compile_fail("tests/build/07.rs");
+}

--- a/crates/sui-gql-client/Cargo.toml
+++ b/crates/sui-gql-client/Cargo.toml
@@ -24,17 +24,25 @@ rustdoc-args = [
 workspace = true
 
 [features]
-default   = ["move-type", "mutations", "queries", "reqwest"]
+default = ["move-type", "mutations", "queries", "reqwest"]
 move-type = ["dep:af-move-type", "dep:bcs", "queries"]
 mutations = ["dep:af-sui-types", "scalars"]
-queries   = ["dep:af-sui-types", "dep:async-stream", "dep:futures", "dep:itertools", "scalars"]
-raw       = ["dep:serde_json"]
-reqwest   = ["cynic/http-reqwest", "dep:reqwest", "raw"]
-scalars   = ["sui-gql-schema/scalars"]
+queries = [
+  "dep:af-sui-types",
+  "dep:async-stream",
+  "dep:futures",
+  "dep:graphql-extract",
+  "dep:itertools",
+  "scalars",
+]
+raw = ["dep:serde_json"]
+reqwest = ["cynic/http-reqwest", "dep:reqwest", "raw"]
+scalars = ["sui-gql-schema/scalars"]
 
 
 [dependencies]
-sui-gql-schema = { version = "0.8.1", path = "../sui-gql-schema", default-features = false }
+graphql-extract = { version = "0.0.1", path = "../graphql-extract", optional = true }
+sui-gql-schema  = { version = "0.8.1", path = "../sui-gql-schema", default-features = false }
 
 bimap            = "0.6"
 clap             = { version = "4", features = ["derive"] }

--- a/crates/sui-gql-client/src/queries/fragments.rs
+++ b/crates/sui-gql-client/src/queries/fragments.rs
@@ -100,6 +100,46 @@ pub(crate) enum TransactionBlockKindInput {
 //  Simple fragments
 // ====================================================================================================
 
+#[derive(cynic::QueryFragment, Clone, Debug, Default)]
+pub(crate) struct PageInfo {
+    pub(crate) has_next_page: bool,
+    pub(crate) end_cursor: Option<String>,
+    #[expect(dead_code, reason = "For generality")]
+    pub(crate) has_previous_page: bool,
+    #[expect(dead_code, reason = "For generality")]
+    pub(crate) start_cursor: Option<String>,
+}
+
+impl From<PageInfoForward> for PageInfo {
+    fn from(
+        PageInfoForward {
+            has_next_page,
+            end_cursor,
+        }: PageInfoForward,
+    ) -> Self {
+        Self {
+            has_next_page,
+            end_cursor,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<PageInfoBackward> for PageInfo {
+    fn from(
+        PageInfoBackward {
+            has_previous_page,
+            start_cursor,
+        }: PageInfoBackward,
+    ) -> Self {
+        Self {
+            has_previous_page,
+            start_cursor,
+            ..Default::default()
+        }
+    }
+}
+
 #[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(graphql_type = "PageInfo")]
 pub struct PageInfoForward {

--- a/crates/sui-gql-client/src/queries/full_objects.rs
+++ b/crates/sui-gql-client/src/queries/full_objects.rs
@@ -1,11 +1,15 @@
 use std::collections::HashMap;
 
 use af_sui_types::{Object, ObjectId};
+use futures::{StreamExt as _, TryStreamExt as _};
+use graphql_extract::extract;
 use itertools::{Either, Itertools as _};
+use sui_gql_schema::scalars::Base64Bcs;
 
-use super::fragments::{ObjectFilter, ObjectKey, PageInfoForward};
+use super::fragments::{ObjectFilter, ObjectKey, PageInfo, PageInfoForward};
+use super::stream;
 use crate::queries::Error;
-use crate::{missing_data, scalars, schema, GraphQlClient, Paged};
+use crate::{missing_data, schema, GraphQlClient, GraphQlResponseExt as _};
 
 pub(super) async fn query<C: GraphQlClient>(
     client: &C,
@@ -29,7 +33,7 @@ pub(super) async fn query<C: GraphQlClient>(
 
     #[expect(
         deprecated,
-        reason = "TODO: build query from scratch with new ObjectFilter"
+        reason = "TODO: build query from scratch with new ObjectFilter and Query.multiGetObjects"
     )]
     let filter = ObjectFilter {
         object_ids: Some(object_ids),
@@ -42,29 +46,54 @@ pub(super) async fn query<C: GraphQlClient>(
         filter: Some(filter),
     };
 
-    let (init, pages) = client
-        .query_paged::<Query>(vars)
-        .await
-        .map_err(Error::Client)?
-        .try_into_data()?
-        .ok_or(missing_data!("Empty response data"))?;
+    let raw_objs: HashMap<_, _> = stream::forward(client, vars, request)
+        .map(|r| -> super::Result<_, C> {
+            let (id, obj) = r?;
+            Ok((id, obj.ok_or_else(|| missing_data!("BCS for {id}"))?))
+        })
+        .try_collect()
+        .await?;
 
-    let mut raw_objs = HashMap::new();
-    let init_nodes = init.objects.nodes;
-    let page_nodes = pages.into_iter().flat_map(|q| q.objects.nodes);
-    for ObjectGql { id, object } in init_nodes.into_iter().chain(page_nodes) {
-        let wrapped = object.ok_or(missing_data!("Bcs for object {id}"))?;
-        raw_objs.insert(id, wrapped.into_inner());
-    }
     // Ensure all requested objects were returned
     for id in requested {
         raw_objs
             .contains_key(&id)
             .then_some(())
-            .ok_or(missing_data!("Object version for {id}"))?;
+            .ok_or(missing_data!("Object {id}"))?;
     }
 
     Ok(raw_objs)
+}
+
+async fn request<C: GraphQlClient>(
+    client: &C,
+    vars: Variables,
+) -> super::Result<
+    stream::Page<impl Iterator<Item = super::Result<(ObjectId, Option<Object>), C>> + 'static>,
+    C,
+> {
+    let data = client
+        .query::<Query, _>(vars)
+        .await
+        .map_err(Error::Client)?
+        .try_into_data()?;
+
+    extract!(data => {
+        objects {
+            nodes[] {
+                id
+                object
+            }
+            page_info
+        }
+    });
+    Ok(stream::Page::new(
+        page_info,
+        nodes.map(|r| -> super::Result<_, C> {
+            let (id, obj) = r?;
+            Ok((id, obj.map(Base64Bcs::into_inner)))
+        }),
+    ))
 }
 
 #[derive(cynic::QueryVariables, Clone, Debug)]
@@ -74,32 +103,17 @@ struct Variables {
     first: Option<i32>,
 }
 
+impl stream::UpdatePageInfo for Variables {
+    fn update_page_info(&mut self, info: &PageInfo) {
+        self.after.clone_from(&info.end_cursor);
+    }
+}
+
 #[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(variables = "Variables")]
 struct Query {
     #[arguments(filter: $filter, first: $first, after: $after)]
     objects: ObjectConnection,
-}
-
-impl Paged for Query {
-    type Input = Variables;
-
-    type NextInput = Variables;
-
-    type NextPage = Self;
-
-    fn next_variables(&self, mut prev_vars: Self::Input) -> Option<Self::NextInput> {
-        let PageInfoForward {
-            has_next_page,
-            end_cursor,
-        } = &self.objects.page_info;
-        if *has_next_page {
-            prev_vars.after.clone_from(end_cursor);
-            Some(prev_vars)
-        } else {
-            None
-        }
-    }
 }
 
 // =============================================================================
@@ -119,7 +133,7 @@ struct ObjectGql {
     #[cynic(rename = "address")]
     id: ObjectId,
     #[cynic(rename = "bcs")]
-    object: Option<scalars::Base64Bcs<Object>>,
+    object: Option<Base64Bcs<Object>>,
 }
 
 #[cfg(test)]

--- a/crates/sui-gql-client/src/queries/genesis_tx.rs
+++ b/crates/sui-gql-client/src/queries/genesis_tx.rs
@@ -1,26 +1,29 @@
 use af_sui_types::TransactionData;
-use cynic::GraphQlResponse;
+use graphql_extract::extract;
 
 use super::Error;
-use crate::{missing_data, scalars, schema, GraphQlClient, GraphQlResponseExt as _};
+use crate::{scalars, schema, GraphQlClient, GraphQlResponseExt as _};
 
 pub async fn query<C: GraphQlClient>(client: &C) -> Result<TransactionData, Error<C::Error>> {
-    let result: GraphQlResponse<Query> = client
-        .query(Variables { id: Some(0) })
+    let data = client
+        .query::<Query, _>(Variables { id: Some(0) })
         .await
-        .map_err(Error::Client)?;
-    let wrapped = result
-        .try_into_data()?
-        .ok_or_else(|| missing_data!("No data"))?
-        .epoch
-        .ok_or_else(|| missing_data!("epoch"))?
-        .transaction_blocks
-        .nodes
-        .pop()
-        .ok_or_else(|| missing_data!("transaction_blocks"))?
-        .bcs
-        .ok_or_else(|| missing_data!("bcs"))?;
-    Ok(wrapped.into_inner())
+        .map_err(Error::Client)?
+        .try_into_data()?;
+    extract!(data => {
+        epoch? {
+            transaction_blocks {
+                nodes[] {
+                    bcs?
+                }
+            }
+        }
+    });
+    Ok(nodes
+        .into_iter()
+        .next()
+        .ok_or("No transactions in epoch")??
+        .into_inner())
 }
 
 #[derive(cynic::QueryVariables, Clone, Debug)]

--- a/crates/sui-gql-client/src/queries/latest_checkpoint.rs
+++ b/crates/sui-gql-client/src/queries/latest_checkpoint.rs
@@ -1,5 +1,7 @@
+use graphql_extract::extract;
+
 use crate::queries::Error;
-use crate::{missing_data, schema, GraphQlClient, GraphQlResponseExt as _};
+use crate::{schema, GraphQlClient, GraphQlResponseExt as _};
 
 pub async fn query<C>(client: &C) -> Result<u64, Error<C::Error>>
 where
@@ -9,13 +11,15 @@ where
         .query::<Query, _>(Variables {})
         .await
         .map_err(Error::Client)?
-        .try_into_data()?
-        .ok_or(missing_data!("Null data in response"))?;
+        .try_into_data()?;
 
-    Ok(data
-        .checkpoint
-        .ok_or(missing_data!("Checkpoint"))?
-        .sequence_number)
+    extract!(data => {
+        checkpoint? {
+            sequence_number
+        }
+    });
+
+    Ok(sequence_number)
 }
 
 #[derive(cynic::QueryVariables, Debug)]

--- a/crates/sui-gql-client/src/queries/mod.rs
+++ b/crates/sui-gql-client/src/queries/mod.rs
@@ -307,6 +307,12 @@ impl<C: std::error::Error> From<crate::extract::Error> for Error<C> {
     }
 }
 
+impl<C: std::error::Error> From<&'static str> for Error<C> {
+    fn from(value: &'static str) -> Self {
+        Self::MissingData(value.into())
+    }
+}
+
 /// Helper to generate [`Error::MissingData`].
 ///
 /// Works very much like an `anyhow!`/`eyre!` macro, but intended for the case when trying to


### PR DESCRIPTION
New macro to allow us to do things like this:
```rust
type Item = Result<(MoveType, String), &'static str>;

fn extract(data: Option<Query>) -> Result<(u64, impl Iterator<Item = Item>), &'static str> {
    use graphql_extract::extract;
    use DynamicFieldValue::MoveValue;

    extract!(data => {
        object? {
            version
            dynamic_fields {
                nodes[] {
                    value? {
                        ... on MoveValue {
                            type_
                            bcs
                        }
                    }
                }
            }
        }
    });
    Ok((version, nodes))
}
```

Highly experimental, hence the initial version will be `0.0.1`.

This was a good learning experience in case we need to make a new version of `sui_pkg_sdk!` in the future to parse more complex Move syntax.
