### PR TITLE
pyth hermes features

### DIFF
--- a/crates/pyth-hermes-client/Cargo.toml
+++ b/crates/pyth-hermes-client/Cargo.toml
@@ -20,22 +20,31 @@ rustdoc-args = [
   "-Zunstable-options",
 ]
 
+[features]
+default    = ["rustls-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+stream     = ["dep:eventsource-stream", "dep:futures", "dep:serde_json", "reqwest/stream"]
+
 [dependencies]
-base64             = "0.22"
-eventsource-stream = "0.2"
-futures            = "0.3"
-hex                = "0.4"
-pyth-sdk           = "0.8"
-reqwest            = { version = "0.12", features = ["json", "stream"] }
-serde              = { version = "1", features = ["derive"] }
-serde_json         = "1"
-strum              = { version = "0.26", features = ["derive"] }
-thiserror          = "2"
-url                = "2"
+base64   = "0.22"
+hex      = "0.4"
+pyth-sdk = "0.8"
+# reqwest            = { version = "0.12", default-features = false, features = ["json", "stream"] }
+reqwest   = { version = "0.12", default-features = false, features = ["json"] }
+serde     = { version = "1", features = ["derive"] }
+strum     = { version = "0.26", features = ["derive"] }
+thiserror = "2"
+url       = "2"
+
+eventsource-stream = { version = "0.2", optional = true }
+futures            = { version = "0.3", optional = true }
+serde_json         = { version = "1", optional = true }
 
 [dev-dependencies]
 clap       = { version = "4", features = ["derive"] }
 color-eyre = "0.6"
+serde_json = "1"
 tokio      = { version = "1", features = ["full"] }
 
 [[example]]
@@ -51,5 +60,6 @@ name = "pyth-price-update"
 path = "examples/price_update.rs"
 
 [[example]]
-name = "pyth-price-update-stream"
-path = "examples/price_update_stream.rs"
+name              = "pyth-price-update-stream"
+path              = "examples/price_update_stream.rs"
+required-features = ["stream"]

--- a/crates/pyth-hermes-client/examples/price_update_stream.rs
+++ b/crates/pyth-hermes-client/examples/price_update_stream.rs
@@ -4,6 +4,7 @@ use pyth_hermes_client::{EncodingType, PriceIdInput, PythClient};
 
 #[derive(Parser)]
 struct Args {
+    #[arg(default_value = "0x50c67b3fd225db8912a424dd4baed60ffdde625ed2feaaf283724f9608fea266")]
     ids: Vec<PriceIdInput>,
 
     #[arg(long)]

--- a/crates/pyth-hermes-client/src/lib.rs
+++ b/crates/pyth-hermes-client/src/lib.rs
@@ -14,16 +14,16 @@ mod stream;
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
-    #[error("Building request payload: {0}")]
+    #[error("Building request payload: {0:?}")]
     RequestBuilder(reqwest::Error),
 
     #[error("Executing request to server: {0:?}")]
     Execute(reqwest::Error),
 
-    #[error("Unsuccessful response status: {0}")]
+    #[error("Unsuccessful response status: {0:?}")]
     ResponseStatus(reqwest::Error),
 
-    #[error("Deserializing response body: {0}")]
+    #[error("Deserializing response body: {0:?}")]
     Deserialize(reqwest::Error),
 
     #[cfg(feature = "stream")]

--- a/crates/pyth-hermes-client/src/lib.rs
+++ b/crates/pyth-hermes-client/src/lib.rs
@@ -17,7 +17,7 @@ pub enum Error {
     #[error("Building request payload: {0}")]
     RequestBuilder(reqwest::Error),
 
-    #[error("Executing request to server: {0}")]
+    #[error("Executing request to server: {0:?}")]
     Execute(reqwest::Error),
 
     #[error("Unsuccessful response status: {0}")]

--- a/crates/pyth-hermes-client/src/lib.rs
+++ b/crates/pyth-hermes-client/src/lib.rs
@@ -6,22 +6,31 @@
 //! [`reqwest`]: https://docs.rs/reqwest/latest/reqwest/
 use std::collections::HashMap;
 
-use eventsource_stream::{EventStreamError, Eventsource as _};
-use futures::{Stream, StreamExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "stream")]
+mod stream;
+
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Building request payload: {0}")]
     RequestBuilder(reqwest::Error),
+
     #[error("Executing request to server: {0}")]
     Execute(reqwest::Error),
+
     #[error("Unsuccessful response status: {0}")]
     ResponseStatus(reqwest::Error),
+
     #[error("Deserializing response body: {0}")]
     Deserialize(reqwest::Error),
+
+    #[cfg(feature = "stream")]
     #[error("From event stream: {0}")]
-    EventStream(#[from] EventStreamError<reqwest::Error>),
+    EventStream(#[from] eventsource_stream::EventStreamError<reqwest::Error>),
+
+    #[cfg(feature = "stream")]
     #[error("Deserializing event data: {0}")]
     EventData(serde_json::Error),
 }
@@ -141,66 +150,6 @@ impl PythClient {
             .await
             .map_err(Error::Deserialize)?;
         Ok(result)
-    }
-
-    /// SSE route handler for streaming price updates.
-    ///
-    /// Arguments:
-    /// * `ids`: Get the most recent price update for this set of price feed ids.
-    /// * `encoding`: Optional encoding type. If set, return the price update in the encoding
-    ///   specified by the encoding parameter. Default is [`EncodingType::Hex`].
-    /// * `parsed`: If `true`, include the parsed price update in [`PriceUpdate::parsed`]. Defaults
-    ///   to `false` for this client.
-    /// * `allow_unordered`: If `true`, allows unordered price updates to be included in the stream.
-    /// * `benchmarks_only`: If `true`, only include benchmark prices that are the initial price
-    ///   updates at a given timestamp (i.e., prevPubTime != pubTime).
-    ///
-    /// /v2/updates/price/stream
-    pub async fn stream_price_updates(
-        &self,
-        ids: Vec<PriceIdInput>,
-        encoding: Option<EncodingType>,
-        parsed: Option<bool>,
-        allow_unordered: Option<bool>,
-        benchmarks_only: Option<bool>,
-    ) -> Result<impl Stream<Item = Result<PriceUpdate, Error>>, Error> {
-        #[derive(Serialize)]
-        struct Options {
-            encoding: Option<EncodingType>,
-            parsed: Option<bool>,
-            allow_unordered: Option<bool>,
-            benchmarks_only: Option<bool>,
-        }
-
-        let mut url = self.url.clone();
-        url.set_path("/v2/updates/price/stream");
-
-        let mut builder = self.client.get(url);
-        for id in ids {
-            builder = builder.query(&[("ids[]", id)]);
-        }
-        let request = builder
-            .query(&Options {
-                encoding,
-                parsed: parsed.or(Some(false)),
-                allow_unordered,
-                benchmarks_only,
-            })
-            .build()
-            .map_err(Error::RequestBuilder)?;
-
-        let update_stream = self
-            .client
-            .execute(request)
-            .await
-            .map_err(Error::Execute)?
-            .bytes_stream()
-            .eventsource()
-            .map_err(Error::EventStream)
-            .map(|e| -> Result<PriceUpdate, _> {
-                serde_json::from_str(&e?.data).map_err(Error::EventData)
-            });
-        Ok(update_stream)
     }
 
     /// Get the latest price updates by price feed id.

--- a/crates/pyth-hermes-client/src/stream.rs
+++ b/crates/pyth-hermes-client/src/stream.rs
@@ -1,0 +1,68 @@
+use eventsource_stream::Eventsource as _;
+use futures::{Stream, StreamExt, TryStreamExt};
+use serde::Serialize;
+
+use crate::{EncodingType, Error, PriceIdInput, PriceUpdate};
+
+/// Streams
+impl crate::PythClient {
+    /// SSE route handler for streaming price updates.
+    ///
+    /// Arguments:
+    /// * `ids`: Get the most recent price update for this set of price feed ids.
+    /// * `encoding`: Optional encoding type. If set, return the price update in the encoding
+    ///   specified by the encoding parameter. Default is [`EncodingType::Hex`].
+    /// * `parsed`: If `true`, include the parsed price update in [`PriceUpdate::parsed`]. Defaults
+    ///   to `false` for this client.
+    /// * `allow_unordered`: If `true`, allows unordered price updates to be included in the stream.
+    /// * `benchmarks_only`: If `true`, only include benchmark prices that are the initial price
+    ///   updates at a given timestamp (i.e., prevPubTime != pubTime).
+    ///
+    /// /v2/updates/price/stream
+    pub async fn stream_price_updates(
+        &self,
+        ids: Vec<PriceIdInput>,
+        encoding: Option<EncodingType>,
+        parsed: Option<bool>,
+        allow_unordered: Option<bool>,
+        benchmarks_only: Option<bool>,
+    ) -> Result<impl Stream<Item = Result<PriceUpdate, Error>>, Error> {
+        #[derive(Serialize)]
+        struct Options {
+            encoding: Option<EncodingType>,
+            parsed: Option<bool>,
+            allow_unordered: Option<bool>,
+            benchmarks_only: Option<bool>,
+        }
+
+        let mut url = self.url.clone();
+        url.set_path("/v2/updates/price/stream");
+
+        let mut builder = self.client.get(url);
+        for id in ids {
+            builder = builder.query(&[("ids[]", id)]);
+        }
+        let request = builder
+            .query(&Options {
+                encoding,
+                parsed: parsed.or(Some(false)),
+                allow_unordered,
+                benchmarks_only,
+            })
+            .build()
+            .map_err(Error::RequestBuilder)?;
+
+        let update_stream = self
+            .client
+            .execute(request)
+            .await
+            .map_err(Error::Execute)?
+            .bytes_stream()
+            .eventsource()
+            .map_err(Error::EventStream)
+            .map(|e| -> Result<PriceUpdate, _> {
+                serde_json::from_str(&e?.data).map_err(Error::EventData)
+            });
+        Ok(update_stream)
+    }
+}


### PR DESCRIPTION
- 1288fdc **feat!: make streams optional and allow tls backend choices**
  By default, `pyth-hermes-client` will use the `rustls-tls` feature of
  `reqwest`, since most likely this will be used to make request to
  external Pyth Hermes services via HTTPS
  
  On the other hand, `stream` is an optional feature that guards the SSE
  price stream implementation. Enable that feature if you want price
  subscriptions.

- 5d7a984 **chore: default value for pyth-price-update-stream example**


---


1. Tested it with `cargo hack -p pyth-hermes-client --keep-going --feature-powerset clippy --all-targets`

1. `cd crates/pyth-hermes-client`

1. `cargo run --example pyth-price-feeds`


Without any TLS backend, which `reqwest = { default-features = false, ... }` would imply, we would not be able to connect to either `https://hermes.pyth.network` or `https://hermes-beta.pyth.network` (they use HTTPS). I've verified this by running the `examples/` without any `reqwest` feature.

```
$ cargo run --no-default-features --example pyth-latest-price-update                 
# ...
Error: 
   0: Executing request to server: reqwest::Error { kind: Request, url: "https://hermes-beta.pyth.network/v2/updates/price/latest?ids%5B%5D=0x50c67b3fd225db8912a424dd4baed60ffdde625ed2feaaf283724f9608fea266&parsed=false", source: hyper_util::client::legacy::Error(Connect, "invalid URL, scheme is not http") }

Location:
   crates/pyth-hermes-client/examples/latest_price_update.rs:32

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```
