### PR TITLE
Disable `reqwest` default features for GraphQL client

### DIFF
--- a/crates/sui-gql-client/Cargo.toml
+++ b/crates/sui-gql-client/Cargo.toml
@@ -76,7 +76,7 @@ serde_json = { version = "1", optional = true }
 default-features = false
 features         = ["build"]
 path             = "../sui-gql-schema"
-version = "0.8.4"
+version          = "0.8.4"
 
 
 [dev-dependencies]
@@ -89,6 +89,9 @@ rand       = "0.8"
 serde_json = "1"
 tokio      = { version = "1", features = ["full"] }
 tokio-test = "0.4"
+
+af-sui-types   = { path = "../af-sui-types" }
+sui-gql-schema = { path = "../sui-gql-schema", features = ["scalars"] }
 
 
 [[example]]

--- a/crates/sui-gql-client/Cargo.toml
+++ b/crates/sui-gql-client/Cargo.toml
@@ -59,7 +59,7 @@ async-stream = { version = "0.3", optional = true }
 futures      = { version = "0.3", optional = true }
 
 # Reqwest client (optional)
-reqwest = { version = "0.12", optional = true }
+reqwest = { version = "0.12", default-features = false, optional = true }
 
 # For pre-made queries (optional)
 af-sui-types = { version = "0.7.3", path = "../af-sui-types", optional = true }
@@ -86,6 +86,7 @@ color-eyre = "0.6"
 indicatif  = "0.17"
 insta      = "1"
 rand       = "0.8"
+reqwest    = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 serde_json = "1"
 tokio      = { version = "1", features = ["full"] }
 tokio-test = "0.4"

--- a/crates/sui-gql-client/README.md
+++ b/crates/sui-gql-client/README.md
@@ -49,3 +49,22 @@ as those automatically convert opaque types to more useful ones like [`af_sui_ty
 [`af_sui_types`]: https://docs.rs/af-sui-types/latest/af_sui_types/
 
 <!-- cargo-rdme end -->
+
+## Requests over HTTPS
+
+You need to import the TLS backend feature yourself in order to use HTTPS. Since this crate only provides a client implementation using `reqwest`, that means enabling one of its TLS features, e.g.,
+- `reqwest = { features = ["native-tls"], ... }`
+- `reqwest = { features = ["rustls-tls"], ... }`
+
+Otherwise, you'll get an error like
+```
+$ cargo run --example gql-latest-checkpoint
+# ...
+Error:
+   0: Client error: Inner(ReqwestError(reqwest::Error { kind: Request, url: "https://sui-testnet.mystenlabs.com/graphql", source: hyper_util::client::legacy::Error(Connect, "invalid URL, scheme is not http") }))
+
+Location:
+   crates/sui-gql-client/examples/latest_checkpoint.rs:21
+```
+
+This is why the `[dev-dependencies]` here use `reqwest = { features = ["rustls-tls"], ... }`, otherwise the crate examples would fail.

--- a/crates/sui-gql-client/src/extract.rs
+++ b/crates/sui-gql-client/src/extract.rs
@@ -1,5 +1,6 @@
 //! Defines [`extract!`](crate::extract!) and its [`Error`].
 
+#[cfg(feature = "queries")]
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 /// Error for [`extract!`](crate::extract!).

--- a/crates/sui-gql-client/src/queries/mod.rs
+++ b/crates/sui-gql-client/src/queries/mod.rs
@@ -293,7 +293,7 @@ impl<T: GraphQlClient> GraphQlClientExt for T {}
 /// Generic error type for queries.
 #[derive(thiserror::Error, Clone, Debug)]
 pub enum Error<C: std::error::Error> {
-    #[error("Client error: {0}")]
+    #[error("Client error: {0:?}")]
     Client(C),
     #[error("In server response: {0}")]
     Server(#[from] GraphQlErrors),


### PR DESCRIPTION
- 810aa83 **fix: required features**
  Some tests would fail to compile under some feature combinations because
  the dependencies weren't properly listed in `[dev-dependencies]`

- 34dcfc3 **feat: disable `reqwest` default features**
  For TLS backends, enable the `reqwest` feature for the backend you want
  to use.

---

## Requests over HTTPS

You need to import the TLS backend feature yourself in order to use HTTPS. Since this crate only provides a client implementation using `reqwest`, that means enabling one of its TLS features, e.g.,
- `reqwest = { features = ["native-tls"], ... }`
- `reqwest = { features = ["rustls-tls"], ... }`

Otherwise, you'll get an error like
```
$ cargo run --example gql-latest-checkpoint 
# ...
Error: 
   0: Client error: Inner(ReqwestError(reqwest::Error { kind: Request, url: "https://sui-testnet.mystenlabs.com/graphql", source: hyper_util::client::legacy::Error(Connect, "invalid URL, scheme is not http") }))

Location:
   crates/sui-gql-client/examples/latest_checkpoint.rs:21
```

This is why the `[dev-dependencies]` here use `reqwest = { features = ["rustls-tls"], ... }`, otherwise the crate examples would fail.

## `reqwest` features enabled

Only at most the `reqwest/json` feature will be enabled.

With no default features, `reqwest` isn't even a dependency
```
$ cargo tree --no-default-features -e normal,features -i reqwest
warning: nothing to print.

To find dependencies that require specific target platforms, try to use option `--target all` first, and then narrow your search scope accordingly.
```

With default features, only `reqwest/json` is enabled
```
$ cargo tree -e normal,features -i reqwest              
reqwest v0.12.7
└── sui-gql-client v0.14.7 (/home/doom/git/AftermathFinance/aftermath-sdk-rust/crates/sui-gql-client)
    ├── sui-gql-client feature "default" (command-line)
    ├── sui-gql-client feature "move-type"
    │   └── sui-gql-client feature "default" (command-line)
    ├── sui-gql-client feature "mutations"
    │   └── sui-gql-client feature "default" (command-line)
    ├── sui-gql-client feature "queries"
    │   ├── sui-gql-client feature "default" (command-line)
    │   └── sui-gql-client feature "move-type" (*)
    ├── sui-gql-client feature "raw"
    │   └── sui-gql-client feature "reqwest"
    │       └── sui-gql-client feature "default" (command-line)
    ├── sui-gql-client feature "reqwest" (*)
    └── sui-gql-client feature "scalars"
        ├── sui-gql-client feature "mutations" (*)
        └── sui-gql-client feature "queries" (*)
└── reqwest feature "json"
    └── cynic v3.9.1
        ├── cynic feature "default"
        │   ├── sui-gql-client v0.14.7 (/home/doom/git/AftermathFinance/aftermath-sdk-rust/crates/sui-gql-client) (*)
        │   └── sui-gql-schema v0.8.4 (/home/doom/git/AftermathFinance/aftermath-sdk-rust/crates/sui-gql-schema)
        │       └── sui-gql-client v0.14.7 (/home/doom/git/AftermathFinance/aftermath-sdk-rust/crates/sui-gql-client) (*)
        │       └── sui-gql-schema feature "scalars"
        │           └── sui-gql-client feature "scalars" (*)
        ├── cynic feature "http-reqwest"
        │   └── sui-gql-client feature "reqwest" (*)
        ├── cynic feature "reqwest"
        │   └── cynic feature "http-reqwest" (*)
        └── cynic feature "serde_json"
            └── cynic feature "http-reqwest" (*)
```

Even with all features enabled, the `reqwest` features remain the same
```
$ cargo tree --all-features -e normal,features -i reqwest
reqwest v0.12.7
└── sui-gql-client v0.14.7 (/home/doom/git/AftermathFinance/aftermath-sdk-rust/crates/sui-gql-client)
    ├── sui-gql-client feature "default" (command-line)
    ├── sui-gql-client feature "move-type" (command-line)
    │   └── sui-gql-client feature "default" (command-line)
    ├── sui-gql-client feature "mutations" (command-line)
    │   └── sui-gql-client feature "default" (command-line)
    ├── sui-gql-client feature "queries" (command-line)
    │   ├── sui-gql-client feature "default" (command-line)
    │   └── sui-gql-client feature "move-type" (command-line) (*)
    ├── sui-gql-client feature "raw" (command-line)
    │   └── sui-gql-client feature "reqwest" (command-line)
    │       └── sui-gql-client feature "default" (command-line)
    ├── sui-gql-client feature "reqwest" (command-line) (*)
    └── sui-gql-client feature "scalars" (command-line)
        ├── sui-gql-client feature "mutations" (command-line) (*)
        └── sui-gql-client feature "queries" (command-line) (*)
└── reqwest feature "json"
    └── cynic v3.9.1
        ├── cynic feature "default"
        │   ├── sui-gql-client v0.14.7 (/home/doom/git/AftermathFinance/aftermath-sdk-rust/crates/sui-gql-client) (*)
        │   └── sui-gql-schema v0.8.4 (/home/doom/git/AftermathFinance/aftermath-sdk-rust/crates/sui-gql-schema)
        │       └── sui-gql-client v0.14.7 (/home/doom/git/AftermathFinance/aftermath-sdk-rust/crates/sui-gql-client) (*)
        │       └── sui-gql-schema feature "scalars"
        │           └── sui-gql-client feature "scalars" (command-line) (*)
        ├── cynic feature "http-reqwest"
        │   └── sui-gql-client feature "reqwest" (command-line) (*)
        ├── cynic feature "reqwest"
        │   └── cynic feature "http-reqwest" (*)
        └── cynic feature "serde_json"
            └── cynic feature "http-reqwest" (*)
```
