### PR TITLE
chore: bump `af-utilities` dependents

### DIFF
--- a/crates/af-iperps/Cargo.toml
+++ b/crates/af-iperps/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Move types for the `Perpetuals` package"
 name        = "af-iperps"
-version     = "0.23.12"
+version     = "0.24.0"
 
 authors.workspace    = true
 categories.workspace = true

--- a/crates/af-oracle/Cargo.toml
+++ b/crates/af-oracle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Move types for Aftermath's `AfOracle` package"
 name        = "af-oracle"
-version     = "0.15.12"
+version     = "0.16.0"
 
 authors.workspace    = true
 categories.workspace = true

--- a/crates/af-pyth-wrapper/Cargo.toml
+++ b/crates/af-pyth-wrapper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Move types for Aftermath's `PythWrapper` package that extends `AfOracle`"
 name        = "af-pyth-wrapper"
-version     = "0.17.12"
+version     = "0.18.0"
 
 authors.workspace    = true
 categories.workspace = true
@@ -36,7 +36,7 @@ graphql = [
 ptb = ["dep:af-ptbuilder", "dep:extension-traits"]
 
 [dependencies]
-af-oracle         = { version = "0.15.12", path = "../af-oracle" }
+af-oracle         = { version = "0.16.0", path = "../af-oracle" }
 af-sui-pkg-sdk    = { version = "0.8.6", path = "../af-sui-pkg-sdk" }
 sui-framework-sdk = { version = "0.10.6", path = "../sui-framework-sdk" }
 


### PR DESCRIPTION
These dependents use the crate's types in their public API, so they must
go through a major version bump after the crate goes through one.
