### PR TITLE
testnet v1.45.0

### DIFF
--- a/crates/sui-jsonrpc/src/msgs/sui_transaction.rs
+++ b/crates/sui-jsonrpc/src/msgs/sui_transaction.rs
@@ -913,12 +913,15 @@ impl Display for SuiTransactionBlockEffects {
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct DryRunTransactionBlockResponse {
     pub effects: SuiTransactionBlockEffects,
     pub events: SuiTransactionBlockEvents,
     pub object_changes: Vec<ObjectChange>,
     pub balance_changes: Vec<BalanceChange>,
     pub input: SuiTransactionBlockData,
+    #[serde(default)]
+    pub execution_error_source: Option<String>,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Default, Serialize, Deserialize)]


### PR DESCRIPTION
The first commit is a consequence of an addition to `JSON-RPC` in `testnet-v1.45.0`. Unfortunately, it is a breaking change **on the Rust side**, but only there, since the struct wasn't marked as `non_exhaustive`.

The second commit addresses a bug that was already there.

- **feat(sui-jsonrpc)!: add `DryRunTransactionBlockResponse::execution_error_source`**
- **fix(sui-jsonrpc): recreate `UserSignature` serialization used in the RPC**
