### PR TITLE
feat!: bump minor version due to public dependency on `sui-jsonrpc`

### DIFF
--- a/crates/pyth-sui-sdk/Cargo.toml
+++ b/crates/pyth-sui-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "SDK for Pyth's Sui package; maintained by Aftermath"
 name        = "pyth-sui-sdk"
-version     = "0.15.13"
+version     = "0.16.0"
 
 authors.workspace    = true
 categories.workspace = true


### PR DESCRIPTION
This crate uses types from `sui-jsonrpc` in its public API when feature
`json-rpc` is enabled
