### PR TITLE
fix!: signal that stream doesn't use the client's lifetime

### DIFF
--- a/crates/pyth-hermes-client/src/stream.rs
+++ b/crates/pyth-hermes-client/src/stream.rs
@@ -26,7 +26,7 @@ impl crate::PythClient {
         parsed: Option<bool>,
         allow_unordered: Option<bool>,
         benchmarks_only: Option<bool>,
-    ) -> Result<impl Stream<Item = Result<PriceUpdate, Error>>, Error> {
+    ) -> Result<impl Stream<Item = Result<PriceUpdate, Error>> + use<>, Error> {
         #[derive(Serialize)]
         struct Options {
             encoding: Option<EncodingType>,


### PR DESCRIPTION
This was preventing users from acquiring mutable references to types
containing the client as the borrow checker would believe the latter was
being immutably borrowed while the stream was alive
