### PR TITLE
feat(af-keys)!: upgrade `fastcrypto` dep

### DIFF
--- a/crates/af-keys/Cargo.toml
+++ b/crates/af-keys/Cargo.toml
@@ -29,7 +29,7 @@ bcs           = "0.1"
 derive_more   = { version = "2", features = ["as_ref", "from"] }
 enum_dispatch = "0.3"
 eyre          = "0.6"
-fastcrypto    = ">=0.1,<0.1.9"
+fastcrypto    = "0.1.9"
 once_cell     = "1"
 serde         = "1"
 serde_json    = "1"


### PR DESCRIPTION
- 1ff5f2b **feat(af-keys)!: upgrade `fastcrypto` dep**
  `fastcrypto` has a breaking change that was not conveyed through SemVer.
  We properly communicate that wherever we were forced to update the
  errors (implementing their trait interfaces)
