### PR TITLE
feat(sui-gql-client): `GraphQlClientExt::object_arg`

### DIFF
--- a/crates/af-keys/src/multisig.rs
+++ b/crates/af-keys/src/multisig.rs
@@ -121,6 +121,10 @@ impl MultiSig {
         &self.multisig_pk
     }
 
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "Not changing the public API right now"
+    )]
     pub fn get_sigs(&self) -> &[CompressedSignature] {
         &self.sigs
     }

--- a/crates/af-sui-types/src/sui/transaction/data.rs
+++ b/crates/af-sui-types/src/sui/transaction/data.rs
@@ -266,6 +266,10 @@ impl ObjectArg {
     }
 
     /// For shared object arguments: set their `mutable` flag value.
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "Not changing the public API right now"
+    )]
     pub fn set_mutable(&mut self, mutable_: bool) -> Result<(), ImmOwnedOrReceivingError> {
         match self {
             Self::SharedObject { mutable, .. } => {

--- a/crates/sui-gql-client/examples/object_args.rs
+++ b/crates/sui-gql-client/examples/object_args.rs
@@ -1,21 +1,29 @@
+use clap::Parser;
 use color_eyre::Result;
 use sui_gql_client::object_args;
 use sui_gql_client::reqwest::ReqwestClient;
 
-const SUI_GRAPHQL_SERVER_URL: &str = "https://sui-testnet.mystenlabs.com/graphql";
+#[derive(Parser)]
+struct Args {
+    #[arg(long, default_value = "https://sui-testnet.mystenlabs.com/graphql")]
+    rpc: String,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let client = ReqwestClient::new(
-        reqwest::Client::default(),
-        SUI_GRAPHQL_SERVER_URL.to_owned(),
-    );
+    let Args { rpc } = Args::parse();
+    let client = ReqwestClient::new_default(rpc);
     object_args!({
         mut clearing_house: "0xe4a1c0bfc53a7c2941a433a9a681c942327278b402878e0c45280eecd098c3d1".parse()?,
         registry: "0x400e84251a6ce2192f69c1aa775d68bab7690e059578317bf9e844d40e07e04d".parse()?,
     } with { &client } paged by 10);
     println!("{clearing_house:?}");
     println!("{registry:?}");
+
+    object_args!({
+        mut ch: "0xe4a1c0bfc53a7c2941a433a9a681c942327278b402878e0c45280eecd098c3d1".parse()?,
+    } with { &client });
+    println!("{ch:?}");
     Ok(())
 }

--- a/crates/sui-gql-client/src/queries/mod.rs
+++ b/crates/sui-gql-client/src/queries/mod.rs
@@ -34,6 +34,7 @@ mod latest_package;
 mod latest_version_at_checkpoint_v2;
 mod max_page_size;
 mod multi_get_objects;
+mod object_arg;
 mod object_args;
 mod object_args_and_content;
 mod object_content;
@@ -165,6 +166,11 @@ pub trait GraphQlClientExt: GraphQlClient + Sized {
         ckpt_num: u64,
     ) -> std::result::Result<u64, LatestVersionAtCheckpointError<Self::Error>> {
         latest_version_at_checkpoint_v2::query(self, id, ckpt_num)
+    }
+
+    /// Get the object argument for a programmable transaction.
+    async fn object_arg(&self, id: ObjectId) -> Result<ObjectArg, Self> {
+        object_arg::query(self, id)
     }
 
     /// Turn a bijective map of names and object ids into one of names and object args.

--- a/crates/sui-gql-client/src/queries/object_arg.rs
+++ b/crates/sui-gql-client/src/queries/object_arg.rs
@@ -1,0 +1,89 @@
+use af_sui_types::{ObjectArg, ObjectId, Version};
+use cynic::{QueryFragment, QueryVariables};
+
+use super::Error;
+use super::object_args::ObjectOwner;
+use crate::{GraphQlClient, GraphQlResponseExt as _, scalars, schema};
+
+/// Get the full [`Object`] contents from the server at a certain version or the latest if not
+/// specified.
+pub(super) async fn query<C>(client: &C, object_id: ObjectId) -> Result<ObjectArg, Error<C::Error>>
+where
+    C: GraphQlClient,
+{
+    let data = client
+        .query::<Query, _>(Variables { address: object_id })
+        .await
+        .map_err(Error::Client)?
+        .try_into_data()?;
+
+    graphql_extract::extract!(data => {
+        object? {
+            object_id
+            version
+            digest
+            owner?
+        }
+    });
+    let oarg = super::object_args::build_object_arg_default(object_id, version, owner, digest)
+        .ok_or(Error::MissingData("Digest for owned object".into()))?;
+    Ok(oarg)
+}
+
+#[derive(QueryVariables, Debug)]
+struct Variables {
+    address: ObjectId,
+}
+
+#[derive(QueryFragment, Debug)]
+#[cynic(variables = "Variables")]
+struct Query {
+    #[arguments(address: $address)]
+    object: Option<GqlObject>,
+}
+
+#[derive(QueryFragment, Debug)]
+#[cynic(graphql_type = "Object")]
+struct GqlObject {
+    #[cynic(rename = "address")]
+    object_id: ObjectId,
+    version: Version,
+    digest: Option<scalars::Digest>,
+    owner: Option<ObjectOwner>,
+}
+
+#[cfg(test)]
+#[test]
+fn gql_output() {
+    use cynic::QueryBuilder as _;
+
+    let vars = Variables {
+        address: ObjectId::ZERO,
+    };
+    let operation = Query::build(vars);
+    insta::assert_snapshot!(operation.query, @r###"
+    query Query($address: SuiAddress!) {
+      object(address: $address) {
+        address
+        version
+        digest
+        owner {
+          __typename
+          ... on Immutable {
+            _
+          }
+          ... on Shared {
+            __typename
+            initialSharedVersion
+          }
+          ... on Parent {
+            __typename
+          }
+          ... on AddressOwner {
+            __typename
+          }
+        }
+      }
+    }
+    "###);
+}

--- a/crates/sui-gql-client/src/queries/object_args.rs
+++ b/crates/sui-gql-client/src/queries/object_args.rs
@@ -162,6 +162,27 @@ fn gql_output() {
 /// ```
 #[macro_export]
 macro_rules! object_args {
+    // Optimization: 1 object arg only
+    (
+        { $name:ident: $object_id:expr_2021 $(,)? }
+        with { $client:expr_2021 }
+    ) => {
+        let $name = $crate::queries::GraphQlClientExt::object_arg($client, $object_id)
+            .await?;
+    };
+
+    (
+        { mut $name:ident: $object_id:expr_2021 $(,)? }
+        with { $client:expr_2021 }
+    ) => {
+        let $name = {
+            let mut oarg = $crate::queries::GraphQlClientExt::object_arg($client, $object_id)
+                .await?;
+            oarg.set_mutable(true)?;
+            oarg
+        };
+    };
+
     (
         {$($tt:tt)*}
         with { $client:expr_2021 } $(paged by $page_size:expr_2021)?
@@ -259,7 +280,7 @@ impl Object {
     }
 }
 
-fn build_object_arg_default(
+pub(crate) fn build_object_arg_default(
     id: ObjectId,
     version: Version,
     owner: ObjectOwner,

--- a/crates/sui-jsonrpc/src/client.rs
+++ b/crates/sui-jsonrpc/src/client.rs
@@ -309,11 +309,19 @@ impl SuiClient {
     }
 
     /// Returns a list of RPC methods supported by the node the client is connected to.
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "Not changing the public API right now"
+    )]
     pub fn available_rpc_methods(&self) -> &Vec<String> {
         &self.info.rpc_methods
     }
 
     /// Returns a list of streaming/subscription APIs supported by the node the client is connected to.
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "Not changing the public API right now"
+    )]
     pub fn available_subscriptions(&self) -> &Vec<String> {
         &self.info.subscriptions
     }
@@ -322,6 +330,10 @@ impl SuiClient {
     ///
     /// The format of this string is `<major>.<minor>.<patch>`, e.g., `1.6.0`,
     /// and it is retrieved from the OpenRPC specification via the discover service method.
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "Not changing the public API right now"
+    )]
     pub fn api_version(&self) -> &str {
         &self.info.version
     }
@@ -340,11 +352,19 @@ impl SuiClient {
     }
 
     /// Returns a reference to the underlying http client.
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "Not changing the public API right now"
+    )]
     pub fn http(&self) -> &HttpClient {
         &self.http
     }
 
     /// Returns a reference to the underlying WebSocket client, if any.
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "Not changing the public API right now"
+    )]
     pub fn ws(&self) -> Option<&WsClient> {
         (*self.ws).as_ref()
     }

--- a/crates/sui-jsonrpc/src/msgs/sui_transaction.rs
+++ b/crates/sui-jsonrpc/src/msgs/sui_transaction.rs
@@ -1041,7 +1041,7 @@ impl SuiExecutionStatus {
     const MOVE_ABORT_PATTERN: &str = r#"MoveAbort\(MoveLocation \{ module: ModuleId \{ address: ([[:alnum:]]+), name: Identifier\("([[:word:]]+)"\) \}, function: (\d+), instruction: (\d+), function_name: Some\("([[:word:]]+)"\) \}, (\d+)\)"#;
 
     pub fn is_ok(&self) -> bool {
-        matches!(self, SuiExecutionStatus::Success { .. })
+        matches!(self, SuiExecutionStatus::Success)
     }
 
     pub fn is_err(&self) -> bool {


### PR DESCRIPTION
Also optimizes `object_args!` when there's only one to fetch
