### PR TITLE
af sui types patch

### DIFF
--- a/crates/af-sui-types/Cargo.toml
+++ b/crates/af-sui-types/Cargo.toml
@@ -52,9 +52,11 @@ uint            = { version = "0.9", optional = true }
 proptest = { version = "1", optional = true }
 
 [dev-dependencies]
-insta      = "1"
-proptest   = "1"
-serde_json = "1"
+insta         = "1"
+proptest      = "1"
+serde_json    = "1"
+sui-sdk-types = { version = "0.0.3", features = ["proptest"] }
+test-strategy = "0.4"
 
 [[test]]
 name              = "bcs"

--- a/crates/af-sui-types/src/sui/transaction/data.rs
+++ b/crates/af-sui-types/src/sui/transaction/data.rs
@@ -64,7 +64,6 @@ impl TransactionData {
     }
 
     /// Deserialize a transaction from base64 bytes.
-    #[deprecated = "Unnecessary &self; will be removed with the next breaking change"]
     pub fn decode_base64(value: impl AsRef<[u8]>) -> Result<Self, TransactionFromBase64Error> {
         Ok(bcs::from_bytes(&decode_base64_default(value).map_err(
             |e| TransactionFromBase64Error::Base64(e.to_string()),

--- a/crates/af-sui-types/src/sui/transaction/data.rs
+++ b/crates/af-sui-types/src/sui/transaction/data.rs
@@ -401,3 +401,18 @@ impl TransactionDataAPI for TransactionDataV1 {
         &mut self.gas_data
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use test_strategy::proptest;
+
+    use super::*;
+
+    #[proptest]
+    fn transaction_data_base64_roundtrip(transaction: sui_sdk_types::Transaction) {
+        let original: TransactionData = transaction.into();
+        let reconstructed = TransactionData::decode_base64(original.encode_base64())
+            .expect("Valid base64 transaction");
+        assert_eq!(original, reconstructed);
+    }
+}


### PR DESCRIPTION
- **chore(af-sui-types): remove erroneus deprecation**
- **test(af-sui-types): ensure TransactionData roundtrip through base64 is valid**
