### PR TITLE
`SuiClient` and `af_iperps::errors` improvements

### DIFF
--- a/crates/af-iperps/Cargo.toml
+++ b/crates/af-iperps/Cargo.toml
@@ -50,8 +50,10 @@ sui-framework-sdk = { version = "0.11.5", path = "../sui-framework-sdk" }
 clap        = { version = "4", features = ["derive"] }
 derive_more = { version = "2", features = ["display", "from", "is_variant", "try_into"] }
 num-traits  = "0.2"
+num_enum    = "0.7"
 remain      = "0.2"
 serde       = "1"
+strum       = { version = "0.27", features = ["derive"] }
 thiserror   = "2"
 
 # GraphQL RPC (optional)
@@ -71,7 +73,7 @@ default-features = false
 features         = ["build"]
 optional         = true
 path             = "../sui-gql-schema"
-version = "0.10.4"
+version          = "0.10.4"
 
 
 [dev-dependencies]

--- a/crates/af-iperps/src/errors.rs
+++ b/crates/af-iperps/src/errors.rs
@@ -1,123 +1,142 @@
+// Copyright (c) Aftermath Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #![expect(non_upper_case_globals, reason = "Copied from Move")]
 
-// ClearingHouse ---------------------------------------------------------------
+macro_rules! move_aborts {
+    (module $_:ident::$module:ident {$(
+        $(#[$meta:meta])*
+        const $Error:ident: u64 = $num:literal;
+    )*}) => {
+        $(
+            $(#[$meta])*
+            pub const $Error: u64 = $num;
+        )*
+    };
+}
 
-/// Cannot deposit/withdraw zero coins to/from the account's collateral.
-pub const DepositOrWithdrawAmountZero: u64 = 0;
-/// Orderbook size or price are invalid values
-pub const InvalidSizeOrPrice: u64 = 1;
-/// Index price returned from oracle is 0 or invalid value
-pub const BadIndexPrice: u64 = 2;
-/// Order value in USD is too low
-pub const OrderUsdValueTooLow: u64 = 4;
-/// Passed a vector of invalid order ids to perform force cancellation
-/// during liquidation
-pub const InvalidForceCancelIds: u64 = 5;
-/// Liquidate must be the first operation of the session, if performed.
-pub const LiquidateNotFirstOperation: u64 = 6;
-/// Passed a vector of invalid order ids to cancel
-pub const InvalidCancelOrderIds: u64 = 7;
-/// Ticket has already passed `expire_timestamp` and can only be cancelled
-pub const StopOrderTicketExpired: u64 = 8;
-/// Index price is not at correct value to satisfy stop order conditions
-pub const StopOrderConditionsViolated: u64 = 9;
-/// Index price is not at correct value to satisfy stop order conditions
-pub const WrongOrderDetails: u64 = 10;
-/// Invalid base price feed storage for the clearing house
-pub const InvalidBasePriceFeedStorage: u64 = 11;
-/// Same liquidator and liqee account ids
-pub const SelfLiquidation: u64 = 12;
-/// User trying to access the subaccount is not the one specified by parent
-pub const InvalidSubAccountUser: u64 = 13;
-/// The parent `Account` trying to delete the subaccount is not the correct one.
-pub const WrongParentForSubAccount: u64 = 14;
-/// Raised when trying to delete a subaccount still containing collateral.
-pub const SubAccountContainsCollateral: u64 = 15;
-/// Raised when trying to call a function with the wrong package's version
-pub const WrongVersion: u64 = 16;
-/// Raised when trying to have a session composed by only `start_session` and `end_session`
-pub const EmptySession: u64 = 17;
-/// Market already registered in the registry
-pub const MarketAlreadyRegistered: u64 = 18;
-/// Collateral is not registered in the registry
-pub const CollateralIsNotRegistered: u64 = 19;
-/// Market is not registered in the registry
-pub const MarketIsNotRegistered: u64 = 20;
-/// Invalid collateral price feed storage for the clearing house
-pub const InvalidCollateralPriceFeedStorage: u64 = 21;
-/// Fees accrued are negative
-pub const NegativeFeesAccrued: u64 = 22;
-/// Reduce only conditions are not respected for stop order execution
-pub const NotReduceOnlyStopOrder: u64 = 23;
-/// Stop order gas cost provided is not enough
-pub const NotEnoughGasForStopOrder: u64 = 24;
+move_aborts! {
+module perpetuals::errors {
+    // ClearingHouse ---------------------------------------------------------------
 
-// Market ---------------------------------------------------------------
+    /// Cannot deposit/withdraw zero coins to/from the account's collateral.
+    const DepositOrWithdrawAmountZero: u64 = 0;
+    /// Orderbook size or price are invalid values
+    const InvalidSizeOrPrice: u64 = 1;
+    /// Index price returned from oracle is 0 or invalid value
+    const BadIndexPrice: u64 = 2;
+    /// Order value in USD is too low
+    const OrderUsdValueTooLow: u64 = 4;
+    /// Passed a vector of invalid order ids to perform force cancellation
+    /// during liquidation
+    const InvalidForceCancelIds: u64 = 5;
+    /// Liquidate must be the first operation of the session, if performed.
+    const LiquidateNotFirstOperation: u64 = 6;
+    /// Passed a vector of invalid order ids to cancel
+    const InvalidCancelOrderIds: u64 = 7;
+    /// Ticket has already passed `expire_timestamp` and can only be cancelled
+    const StopOrderTicketExpired: u64 = 8;
+    /// Index price is not at correct value to satisfy stop order conditions
+    const StopOrderConditionsViolated: u64 = 9;
+    /// Index price is not at correct value to satisfy stop order conditions
+    const WrongOrderDetails: u64 = 10;
+    /// Invalid base price feed storage for the clearing house
+    const InvalidBasePriceFeedStorage: u64 = 11;
+    /// Same liquidator and liqee account ids
+    const SelfLiquidation: u64 = 12;
+    /// User trying to access the subaccount is not the one specified by parent
+    const InvalidSubAccountUser: u64 = 13;
+    /// The parent `Account` trying to delete the subaccount is not the correct one.
+    const WrongParentForSubAccount: u64 = 14;
+    /// Raised when trying to delete a subaccount still containing collateral.
+    const SubAccountContainsCollateral: u64 = 15;
+    /// Raised when trying to call a function with the wrong package's version
+    const WrongVersion: u64 = 16;
+    /// Raised when trying to have a session composed by only `start_session` and `end_session`
+    const EmptySession: u64 = 17;
+    /// Market already registered in the registry
+    const MarketAlreadyRegistered: u64 = 18;
+    /// Collateral is not registered in the registry
+    const CollateralIsNotRegistered: u64 = 19;
+    /// Market is not registered in the registry
+    const MarketIsNotRegistered: u64 = 20;
+    /// Invalid collateral price feed storage for the clearing house
+    const InvalidCollateralPriceFeedStorage: u64 = 21;
+    /// Fees accrued are negative
+    const NegativeFeesAccrued: u64 = 22;
+    /// Reduce only conditions are not respected for stop order execution
+    const NotReduceOnlyStopOrder: u64 = 23;
+    /// Stop order gas cost provided is not enough
+    const NotEnoughGasForStopOrder: u64 = 24;
 
-/// While creating ordered map with invalid parameters,
-/// or changing them improperly for an existent map.
-pub const InvalidMarketParameters: u64 = 1000;
-/// Tried to call `update_funding` before enough time has passed since the
-/// last update.
-pub const UpdatingFundingTooEarly: u64 = 1001;
-/// Margin ratio update proposal already exists for market
-pub const ProposalAlreadyExists: u64 = 1002;
-/// Margin ratio update proposal cannot be commited too early
-pub const PrematureProposal: u64 = 1003;
-/// Margin ratio update proposal delay is outside the valid range
-pub const InvalidProposalDelay: u64 = 1004;
-/// Margin ratio update proposal does not exist for market
-pub const ProposalDoesNotExist: u64 = 1005;
-/// Exchange has no available fees to withdraw
-pub const NoFeesAccrued: u64 = 1006;
-/// Tried to withdraw more insurance funds than the allowed amount
-pub const InsufficientInsuranceSurplus: u64 = 1007;
-/// Cannot create a market for which a price feed does not exist
-pub const NoPriceFeedForMarket: u64 = 1008;
-/// Cannot delete a proposal that already matured. It can only be committed.
-pub const ProposalAlreadyMatured: u64 = 1009;
+    // Market ---------------------------------------------------------------
 
-// Position  ---------------------------------------------------------------
+    /// While creating ordered map with invalid parameters,
+    /// or changing them improperly for an existent map.
+    const InvalidMarketParameters: u64 = 1000;
+    /// Tried to call `update_funding` before enough time has passed since the
+    /// last update.
+    const UpdatingFundingTooEarly: u64 = 1001;
+    /// Margin ratio update proposal already exists for market
+    const ProposalAlreadyExists: u64 = 1002;
+    /// Margin ratio update proposal cannot be commited too early
+    const PrematureProposal: u64 = 1003;
+    /// Margin ratio update proposal delay is outside the valid range
+    const InvalidProposalDelay: u64 = 1004;
+    /// Margin ratio update proposal does not exist for market
+    const ProposalDoesNotExist: u64 = 1005;
+    /// Exchange has no available fees to withdraw
+    const NoFeesAccrued: u64 = 1006;
+    /// Tried to withdraw more insurance funds than the allowed amount
+    const InsufficientInsuranceSurplus: u64 = 1007;
+    /// Cannot create a market for which a price feed does not exist
+    const NoPriceFeedForMarket: u64 = 1008;
+    /// Cannot delete a proposal that already matured. It can only be committed.
+    const ProposalAlreadyMatured: u64 = 1009;
 
-/// Tried placing a new pending order when the position already has the maximum
-/// allowed number of pending orders.
-pub const MaxPendingOrdersExceeded: u64 = 2000;
-/// Used for checking both liqee and liqor positions during liquidation
-pub const PositionBelowIMR: u64 = 2001;
-/// When leaving liqee's position with a margin ratio above tolerance,
-/// meaning that liqor has overbought position
-pub const PositionAboveTolerance: u64 = 2002;
-/// An operation brought an account below initial margin requirements.
-pub const InitialMarginRequirementViolated: u64 = 2003;
-/// Position is above MMR, so can't be liquidated.
-pub const PositionAboveMMR: u64 = 2004;
-/// Cannot realize bad debt via means other than calling 'liquidate'.
-pub const PositionBadDebt: u64 = 2005;
-/// Cannot withdraw more than the account's free collateral.
-pub const InsufficientFreeCollateral: u64 = 2006;
-/// Cannot have more than 1 position in a market.
-pub const PositionAlreadyExists: u64 = 2007;
-/// Cannot compute deallocate amount for a target MR < IMR.
-pub const DeallocateTargetMrTooLow: u64 = 2008;
+    // Position  ---------------------------------------------------------------
 
-// Orderbook & OrderedMap -------------------------------------------------------
+    /// Tried placing a new pending order when the position already has the maximum
+    /// allowed number of pending orders.
+    const MaxPendingOrdersExceeded: u64 = 2000;
+    /// Used for checking both liqee and liqor positions during liquidation
+    const PositionBelowIMR: u64 = 2001;
+    /// When leaving liqee's position with a margin ratio above tolerance,
+    /// meaning that liqor has overbought position
+    const PositionAboveTolerance: u64 = 2002;
+    /// An operation brought an account below initial margin requirements.
+    const InitialMarginRequirementViolated: u64 = 2003;
+    /// Position is above MMR, so can't be liquidated.
+    const PositionAboveMMR: u64 = 2004;
+    /// Cannot realize bad debt via means other than calling 'liquidate'.
+    const PositionBadDebt: u64 = 2005;
+    /// Cannot withdraw more than the account's free collateral.
+    const InsufficientFreeCollateral: u64 = 2006;
+    /// Cannot have more than 1 position in a market.
+    const PositionAlreadyExists: u64 = 2007;
+    /// Cannot compute deallocate amount for a target MR < IMR.
+    const DeallocateTargetMrTooLow: u64 = 2008;
 
-/// While creating ordered map with wrong parameters.
-pub const InvalidMapParameters: u64 = 3000;
-/// While searching for a key, but it doesn't exist.
-pub const KeyNotExist: u64 = 3001;
-/// While inserting already existing key.
-pub const KeyAlreadyExists: u64 = 3002;
-/// When attempting to destroy a non-empty map
-pub const DestroyNotEmpty: u64 = 3003;
-/// Invalid user tries to modify an order
-pub const InvalidUserForOrder: u64 = 3004;
-/// Orderbook flag requirements violated
-pub const FlagRequirementsViolated: u64 = 3005;
-/// Minimum size matched not reached
-pub const NotEnoughLiquidity: u64 = 3006;
-/// When trying to change a map configuration, but the map has
-/// length less than 4
-pub const MapTooSmall: u64 = 3007;
-/// When taker matches its own order
-pub const SelfTrading: u64 = 3008;
+    // Orderbook & OrderedMap -------------------------------------------------------
+
+    /// While creating ordered map with wrong parameters.
+    const InvalidMapParameters: u64 = 3000;
+    /// While searching for a key, but it doesn't exist.
+    const KeyNotExist: u64 = 3001;
+    /// While inserting already existing key.
+    const KeyAlreadyExists: u64 = 3002;
+    /// When attempting to destroy a non-empty map
+    const DestroyNotEmpty: u64 = 3003;
+    /// Invalid user tries to modify an order
+    const InvalidUserForOrder: u64 = 3004;
+    /// Orderbook flag requirements violated
+    const FlagRequirementsViolated: u64 = 3005;
+    /// Minimum size matched not reached
+    const NotEnoughLiquidity: u64 = 3006;
+    /// When trying to change a map configuration, but the map has
+    /// length less than 4
+    const MapTooSmall: u64 = 3007;
+    /// When taker matches its own order
+    const SelfTrading: u64 = 3008;
+}
+}

--- a/crates/af-iperps/src/errors.rs
+++ b/crates/af-iperps/src/errors.rs
@@ -12,6 +12,23 @@ macro_rules! move_aborts {
             $(#[$meta])*
             pub const $Error: u64 = $num;
         )*
+        #[derive(
+            Debug,
+            PartialEq,
+            Eq,
+            Hash,
+            num_enum::IntoPrimitive,
+            num_enum::TryFromPrimitive,
+            strum::Display,
+            strum::EnumIs,
+            strum::EnumMessage,
+            strum::IntoStaticStr,
+        )]
+        #[repr(u64)]
+        pub enum MoveAbort {$(
+            $(#[$meta])*
+            $Error = $num,
+        )*}
     };
 }
 
@@ -139,4 +156,17 @@ module perpetuals::errors {
     /// When taker matches its own order
     const SelfTrading: u64 = 3008;
 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MoveAbort;
+
+    #[test]
+    fn variant_to_code() {
+        assert_eq!(MoveAbort::MaxPendingOrdersExceeded as u64, 2000);
+        assert_eq!(MoveAbort::SelfTrading as u64, 3008);
+        assert_eq!(Ok(MoveAbort::MaxPendingOrdersExceeded), 2000_u64.try_into());
+        assert_eq!(Ok(MoveAbort::SelfTrading), 3008_u64.try_into());
+    }
 }

--- a/crates/af-iperps/src/snapshots/af_iperps__tests__public_api.snap
+++ b/crates/af-iperps/src/snapshots/af_iperps__tests__public_api.snap
@@ -464,6 +464,133 @@ impl<T: af_move_type::MoveType> core::str::traits::FromStr for af_iperps::cleari
 pub type af_iperps::clearing_house::VaultTypeTag<T>::Err = af_move_type::ParseStructTagError
 pub fn af_iperps::clearing_house::VaultTypeTag<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub mod af_iperps::errors
+#[repr(u64)] pub enum af_iperps::errors::MoveAbort
+pub af_iperps::errors::MoveAbort::BadIndexPrice = 2
+pub af_iperps::errors::MoveAbort::CollateralIsNotRegistered = 19
+pub af_iperps::errors::MoveAbort::DeallocateTargetMrTooLow = 2008
+pub af_iperps::errors::MoveAbort::DepositOrWithdrawAmountZero = 0
+pub af_iperps::errors::MoveAbort::DestroyNotEmpty = 3003
+pub af_iperps::errors::MoveAbort::EmptySession = 17
+pub af_iperps::errors::MoveAbort::FlagRequirementsViolated = 3005
+pub af_iperps::errors::MoveAbort::InitialMarginRequirementViolated = 2003
+pub af_iperps::errors::MoveAbort::InsufficientFreeCollateral = 2006
+pub af_iperps::errors::MoveAbort::InsufficientInsuranceSurplus = 1007
+pub af_iperps::errors::MoveAbort::InvalidBasePriceFeedStorage = 11
+pub af_iperps::errors::MoveAbort::InvalidCancelOrderIds = 7
+pub af_iperps::errors::MoveAbort::InvalidCollateralPriceFeedStorage = 21
+pub af_iperps::errors::MoveAbort::InvalidForceCancelIds = 5
+pub af_iperps::errors::MoveAbort::InvalidMapParameters = 3000
+pub af_iperps::errors::MoveAbort::InvalidMarketParameters = 1000
+pub af_iperps::errors::MoveAbort::InvalidProposalDelay = 1004
+pub af_iperps::errors::MoveAbort::InvalidSizeOrPrice = 1
+pub af_iperps::errors::MoveAbort::InvalidSubAccountUser = 13
+pub af_iperps::errors::MoveAbort::InvalidUserForOrder = 3004
+pub af_iperps::errors::MoveAbort::KeyAlreadyExists = 3002
+pub af_iperps::errors::MoveAbort::KeyNotExist = 3001
+pub af_iperps::errors::MoveAbort::LiquidateNotFirstOperation = 6
+pub af_iperps::errors::MoveAbort::MapTooSmall = 3007
+pub af_iperps::errors::MoveAbort::MarketAlreadyRegistered = 18
+pub af_iperps::errors::MoveAbort::MarketIsNotRegistered = 20
+pub af_iperps::errors::MoveAbort::MaxPendingOrdersExceeded = 2000
+pub af_iperps::errors::MoveAbort::NegativeFeesAccrued = 22
+pub af_iperps::errors::MoveAbort::NoFeesAccrued = 1006
+pub af_iperps::errors::MoveAbort::NoPriceFeedForMarket = 1008
+pub af_iperps::errors::MoveAbort::NotEnoughGasForStopOrder = 24
+pub af_iperps::errors::MoveAbort::NotEnoughLiquidity = 3006
+pub af_iperps::errors::MoveAbort::NotReduceOnlyStopOrder = 23
+pub af_iperps::errors::MoveAbort::OrderUsdValueTooLow = 4
+pub af_iperps::errors::MoveAbort::PositionAboveMMR = 2004
+pub af_iperps::errors::MoveAbort::PositionAboveTolerance = 2002
+pub af_iperps::errors::MoveAbort::PositionAlreadyExists = 2007
+pub af_iperps::errors::MoveAbort::PositionBadDebt = 2005
+pub af_iperps::errors::MoveAbort::PositionBelowIMR = 2001
+pub af_iperps::errors::MoveAbort::PrematureProposal = 1003
+pub af_iperps::errors::MoveAbort::ProposalAlreadyExists = 1002
+pub af_iperps::errors::MoveAbort::ProposalAlreadyMatured = 1009
+pub af_iperps::errors::MoveAbort::ProposalDoesNotExist = 1005
+pub af_iperps::errors::MoveAbort::SelfLiquidation = 12
+pub af_iperps::errors::MoveAbort::SelfTrading = 3008
+pub af_iperps::errors::MoveAbort::StopOrderConditionsViolated = 9
+pub af_iperps::errors::MoveAbort::StopOrderTicketExpired = 8
+pub af_iperps::errors::MoveAbort::SubAccountContainsCollateral = 15
+pub af_iperps::errors::MoveAbort::UpdatingFundingTooEarly = 1001
+pub af_iperps::errors::MoveAbort::WrongOrderDetails = 10
+pub af_iperps::errors::MoveAbort::WrongParentForSubAccount = 14
+pub af_iperps::errors::MoveAbort::WrongVersion = 16
+impl af_iperps::errors::MoveAbort
+pub const fn af_iperps::errors::MoveAbort::is_bad_index_price(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_collateral_is_not_registered(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_deallocate_target_mr_too_low(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_deposit_or_withdraw_amount_zero(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_destroy_not_empty(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_empty_session(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_flag_requirements_violated(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_initial_margin_requirement_violated(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_insufficient_free_collateral(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_insufficient_insurance_surplus(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_invalid_base_price_feed_storage(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_invalid_cancel_order_ids(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_invalid_collateral_price_feed_storage(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_invalid_force_cancel_ids(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_invalid_map_parameters(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_invalid_market_parameters(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_invalid_proposal_delay(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_invalid_size_or_price(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_invalid_sub_account_user(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_invalid_user_for_order(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_key_already_exists(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_key_not_exist(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_liquidate_not_first_operation(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_map_too_small(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_market_already_registered(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_market_is_not_registered(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_max_pending_orders_exceeded(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_negative_fees_accrued(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_no_fees_accrued(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_no_price_feed_for_market(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_not_enough_gas_for_stop_order(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_not_enough_liquidity(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_not_reduce_only_stop_order(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_order_usd_value_too_low(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_position_above_mmr(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_position_above_tolerance(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_position_already_exists(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_position_bad_debt(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_position_below_imr(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_premature_proposal(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_proposal_already_exists(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_proposal_already_matured(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_proposal_does_not_exist(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_self_liquidation(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_self_trading(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_stop_order_conditions_violated(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_stop_order_ticket_expired(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_sub_account_contains_collateral(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_updating_funding_too_early(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_wrong_order_details(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_wrong_parent_for_sub_account(&self) -> bool
+pub const fn af_iperps::errors::MoveAbort::is_wrong_version(&self) -> bool
+impl core::convert::From<af_iperps::errors::MoveAbort> for &'static str
+pub fn &'static str::from(x: af_iperps::errors::MoveAbort) -> &'static str
+impl core::convert::From<af_iperps::errors::MoveAbort> for u64
+pub fn u64::from(enum_value: af_iperps::errors::MoveAbort) -> Self
+impl core::convert::TryFrom<u64> for af_iperps::errors::MoveAbort
+pub type af_iperps::errors::MoveAbort::Error = num_enum::TryFromPrimitiveError<af_iperps::errors::MoveAbort>
+pub fn af_iperps::errors::MoveAbort::try_from(number: u64) -> core::result::Result<Self, num_enum::TryFromPrimitiveError<Self>>
+impl core::fmt::Display for af_iperps::errors::MoveAbort
+pub fn af_iperps::errors::MoveAbort::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+impl num_enum::TryFromPrimitive for af_iperps::errors::MoveAbort
+pub type af_iperps::errors::MoveAbort::Error = num_enum::TryFromPrimitiveError<af_iperps::errors::MoveAbort>
+pub type af_iperps::errors::MoveAbort::Primitive = u64
+pub const af_iperps::errors::MoveAbort::NAME: &'static str
+pub fn af_iperps::errors::MoveAbort::try_from_primitive(number: Self::Primitive) -> core::result::Result<Self, num_enum::TryFromPrimitiveError<Self>>
+impl strum::EnumMessage for af_iperps::errors::MoveAbort
+pub fn af_iperps::errors::MoveAbort::get_detailed_message(&self) -> core::option::Option<&'static str>
+pub fn af_iperps::errors::MoveAbort::get_documentation(&self) -> core::option::Option<&'static str>
+pub fn af_iperps::errors::MoveAbort::get_message(&self) -> core::option::Option<&'static str>
+pub fn af_iperps::errors::MoveAbort::get_serializations(&self) -> &'static [&'static str]
+impl<'_derivative_strum> core::convert::From<&'_derivative_strum af_iperps::errors::MoveAbort> for &'static str
+pub fn &'static str::from(x: &'_derivative_strum af_iperps::errors::MoveAbort) -> &'static str
 pub const af_iperps::errors::BadIndexPrice: u64
 pub const af_iperps::errors::CollateralIsNotRegistered: u64
 pub const af_iperps::errors::DeallocateTargetMrTooLow: u64

--- a/crates/sui-jsonrpc/Cargo.toml
+++ b/crates/sui-jsonrpc/Cargo.toml
@@ -25,9 +25,18 @@ rustdoc-args = [
 workspace = true
 
 [features]
-client     = ["client-api", "dep:http", "dep:jsonrpsee", "jsonrpsee/http-client", "jsonrpsee/ws-client"]
+client = [
+  "client-api",
+  "dep:async-stream",
+  "dep:futures-core",
+  "dep:futures-util",
+  "dep:http",
+  "dep:jsonrpsee",
+  "jsonrpsee/http-client",
+  "jsonrpsee/ws-client",
+]
 client-api = ["dep:extension-traits", "jsonrpsee/client-core", "jsonrpsee/macros"]
-default    = ["client"]
+default = ["client"]
 
 [dependencies]
 af-sui-types  = { version = "0.8.4", path = "../af-sui-types" }
@@ -45,7 +54,10 @@ sui-sdk-types = "0.0.3"
 tabled        = "0.12"
 thiserror     = "2"
 
+async-stream     = { version = "0.3", optional = true }
 extension-traits = { version = "2", optional = true }
+futures-core     = { version = "0.3", optional = true }
+futures-util     = { version = "0.3", optional = true }
 http             = { version = "1", optional = true }
 jsonrpsee        = { version = "0.24", optional = true }
 

--- a/crates/sui-jsonrpc/src/client.rs
+++ b/crates/sui-jsonrpc/src/client.rs
@@ -445,6 +445,32 @@ impl SuiClient {
             .await
     }
 
+    /// Helper to dry run a transaction kind for its effects.
+    ///
+    /// This sets the gas budget to the maximum possible. If you want to test different values,
+    /// manually perform the dry-run using the inner [`Self::http`] client.
+    pub async fn dry_run_transaction(
+        &self,
+        tx_kind: &TransactionKind,
+        sender: SuiAddress,
+        gas_price: u64,
+    ) -> Result<DryRunTransactionBlockResponse, JsonRpcClientError> {
+        let sentinel = TransactionData::V1(TransactionDataV1 {
+            kind: tx_kind.clone(),
+            sender,
+            gas_data: GasData {
+                payment: vec![],
+                owner: sender,
+                price: gas_price,
+                budget: MAX_GAS_BUDGET,
+            },
+            expiration: TransactionExpiration::None,
+        });
+        self.http()
+            .dry_run_transaction_block(sentinel.encode_base64())
+            .await
+    }
+
     /// Estimate a budget for the transaction by dry-running it.
     ///
     /// Uses default [`GasBudgetOptions`] to compute the cost estimate.

--- a/crates/sui-jsonrpc/src/error.rs
+++ b/crates/sui-jsonrpc/src/error.rs
@@ -40,6 +40,10 @@ static RETRIED_TRANSACTION_SUCCESS_REGEX: LazyLock<regex::Regex> = LazyLock::new
 impl JsonRpcClientError {
     /// If this is a JSON-RPC [error object], return a reference to it.
     ///
+    /// If submitting a transaction, these are usually pre-execution validity check failures, e.g.,
+    /// wrong signatures, equivocated objects, etc. Use [`ErrorObjectExt`] to extract more
+    /// information from those.
+    ///
     /// [error object]: https://www.jsonrpc.org/specification#response_object
     fn as_error_object(&self) -> Option<&ErrorObjectOwned> {
         match &self {


### PR DESCRIPTION
- f97d1fe **feat(sui-jsonrpc): better coin queries**

- 03d139f **feat(sui-jsonrpc): `SuiClient::submit_transaction`**

- 468b6f3 **feat(sui-jsonrpc)!: `SuiTransactionBlockResponse::sui_effects`**
  Helper to get the network's effects format from the JSON-RPC response

- ec45741 **feat(sui-jsonrpc): `SuiClient::dry_run_transaction`**

- 3a320bd **refactor(af-iperps): Move abort code consts conversion to Rust**

- d43e801 **feat(af-iperps): `MoveAbort` enum with all error codes and documentation**
  This implements:
  - conversions from numerical codes (what we get in `TransactionEffects`)
  - the error documentation, derived from the Move source, using `strum::EnumMessage`
  - the error variant to string using `strum::IntoStaticStr`
