### PR TITLE
fix: bump SemVer-breaking version for `pyth-sui-sdk`

### DIFF
--- a/crates/pyth-sui-sdk/Cargo.toml
+++ b/crates/pyth-sui-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "SDK for Pyth's Sui package; maintained by Aftermath"
 name        = "pyth-sui-sdk"
-version     = "0.17.7"
+version     = "0.18.0"
 
 authors.workspace      = true
 categories.workspace   = true


### PR DESCRIPTION
- 8ce4d23 **fix: bump SemVer-breaking version for `pyth-sui-sdk`**
  The crate depends publicly on `sui-jsonrpc` due to
  `pyth_sui_sdk::read::get_price_info_object_id_from_pyth_state` which
  uses `WriteApiClient`.
  
  Since `sui-jsonrpc` was erroneously updated (SemVer-breaking), then this
  needs to be as well.
