### PR TITLE
feat(af-sui-pkg-sdk): support `Option<T>` type fields

### DIFF
--- a/crates/af-sui-pkg-sdk/examples/display.rs
+++ b/crates/af-sui-pkg-sdk/examples/display.rs
@@ -19,6 +19,11 @@ sui_pkg_sdk!(coin_package {
             other: bool,
         }
     }
+    module opt {
+        struct Optional {
+            inner: Option<u64>
+        }
+    }
 });
 
 fn main() -> anyhow::Result<()> {

--- a/crates/af-sui-pkg-sdk/src/lib.rs
+++ b/crates/af-sui-pkg-sdk/src/lib.rs
@@ -542,6 +542,38 @@ macro_rules! sui_pkg_sdk {
         );
     };
 
+    // #[tabled(format("{}.{}", self.id, self.name))]
+    // -------------------------------------------------------------------------
+    // option field type
+    // -------------------------------------------------------------------------
+    (@Struct
+        $(#[$meta:meta])*
+        $Struct:ident$(<$($G:ident),*>)?
+        []
+        ($(#[$fmeta:meta])* $field:ident: Option<$type:ty> $(, $($rest:tt)*)?)
+        -> { $($result:tt)* }
+    ) => {
+        $crate::sui_pkg_sdk!(@Struct
+            $(#[$meta])*
+            $Struct$(<$($G),*>)?
+            []
+            ($($($rest)*)?)
+            -> {
+                $($result)*
+                $(#[$fmeta])*
+                #[tabled(format(
+                    "{}",
+                    self.$field
+                        .as_ref()
+                        .map(ToString::to_string)
+                        .unwrap_or_else(|| "None".into())
+                ))]
+                pub $field: Option<$type>,
+            }
+        );
+    };
+
+
     // -------------------------------------------------------------------------
     // generic field type
     // -------------------------------------------------------------------------

--- a/crates/af-sui-pkg-sdk/tests/option_field.rs
+++ b/crates/af-sui-pkg-sdk/tests/option_field.rs
@@ -1,0 +1,11 @@
+use af_sui_pkg_sdk::sui_pkg_sdk;
+
+sui_pkg_sdk!(package {
+    module dummy {
+        struct Dummy {
+            option: Option<u64>,
+        }
+    }
+});
+
+fn main() {}

--- a/crates/af-sui-pkg-sdk/tests/tests.rs
+++ b/crates/af-sui-pkg-sdk/tests/tests.rs
@@ -4,4 +4,5 @@ fn tests() {
     t.pass("tests/legacy_move.rs");
     t.pass("tests/tuple_struct.rs");
     t.pass("tests/visibility_modifiers.rs");
+    t.pass("tests/option_field.rs");
 }


### PR DESCRIPTION
Self-explanatory. This gets around the issue that `Option<T>` doesn't
implement `Display` by using the `#[tabled(format(...))]` attribute.

In a future breaking change of `af-sui-pkg-sdk`, this could be used for
`vector<T>` fields to avoid the `MoveVec` type which is annoying to use
