### PR TITLE
refactor: make public dependencies explicit

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+[unstable]
+public-dependency = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,9 @@ jobs:
             - 'crates/**'
             - 'Cargo.toml'
 
-  rustfmt:
+  lint:
     needs: changes
     if: ${{ needs.changes.outputs.rust }}
-    name: Rustfmt
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -45,24 +44,15 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          components: rustfmt
+          components: clippy,rustfmt
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all --check
-
-  clippy:
-    needs: changes
-    if: ${{ needs.changes.outputs.rust }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-      - name: Clippy check
-        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: Check libraries
+        run: cargo +nightly hack --feature-powerset clippy --lib --no-deps -- -D warnings
 
   test:
     needs: changes
@@ -73,10 +63,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@v2
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
         with:
           tool: nextest
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: |-
           cargo nextest run --all-features --all-targets
@@ -92,27 +84,20 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
         with:
           shared-key: "nightly"
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -A rustdoc::redundant-explicit-links -D warnings
         run: cargo doc --no-deps --all-features --workspace --examples
-
-  readme:
-    needs: changes
-    if: ${{ needs.changes.outputs.rust }}
-    name: READMEs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@v2
+      - name: Install Cargo tools
+        uses: taiki-e/install-action@v2
         with:
           tool: cargo-workspaces,cargo-rdme
-      - name: Check if the README is up to date.
+      - name: Check if READMEs are up to date.
         run: |
           cargo ws exec cargo rdme --check --intralinks-strip-links

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ repository   = "https://github.com/AftermathFinance/aftermath-sdk-rust"
 rust-version = "1.85"
 
 [workspace.lints.clippy]
-nursery             = { level = "warn", priority = 1 }
-redundant_pub_crate = { level = "allow", priority = 2 }
-todo                = "warn"
-unwrap_used         = "warn"
+nursery               = { level = "warn", priority = 1 }
+redundant_pub_crate   = { level = "allow", priority = 2 }
+todo                  = "warn"
+uninlined_format_args = "allow"
+unwrap_used           = "warn"
 
 # https://github.com/eyre-rs/color-eyre?tab=readme-ov-file#improving-perf-on-debug-builds
 [profile.dev.package.backtrace]

--- a/crates/af-faucet/Cargo.toml
+++ b/crates/af-faucet/Cargo.toml
@@ -25,8 +25,8 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-af-move-type      = { version = "0.9.7", path = "../af-move-type" }
-af-sui-pkg-sdk    = { version = "0.9.8", path = "../af-sui-pkg-sdk" }
-af-sui-types      = { version = "0.8.7", path = "../af-sui-types" }
-move-stdlib-sdk   = { version = "0.10.8", path = "../move-stdlib-sdk" }
-sui-framework-sdk = { version = "0.11.9", path = "../sui-framework-sdk" }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-sui-pkg-sdk    = { version = "0.9.8", public = true, path = "../af-sui-pkg-sdk" }
+sui-framework-sdk = { version = "0.11.9", public = true, path = "../sui-framework-sdk" }

--- a/crates/af-iperps/Cargo.toml
+++ b/crates/af-iperps/Cargo.toml
@@ -40,20 +40,27 @@ graphql = [
 slo = ["dep:bcs", "dep:fastcrypto"]
 
 [dependencies]
-af-move-type      = { version = "0.9.7", path = "../af-move-type" }
-af-sui-pkg-sdk    = { version = "0.9.8", path = "../af-sui-pkg-sdk" }
-af-sui-types      = { version = "0.8.7", path = "../af-sui-types" }
-af-utilities      = { version = "0.9.7", path = "../af-utilities" }
-move-stdlib-sdk   = { version = "0.10.8", path = "../move-stdlib-sdk" }
-sui-framework-sdk = { version = "0.11.9", path = "../sui-framework-sdk" }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-sui-pkg-sdk    = { version = "0.9.8", public = true, path = "../af-sui-pkg-sdk" }
+af-utilities      = { version = "0.9.7", public = true, path = "../af-utilities" }
+num_enum          = { version = "0.7", public = true }
+strum             = { version = "0.27", public = true, features = ["derive"] }
+sui-framework-sdk = { version = "0.11.9", public = true, path = "../sui-framework-sdk" }
+sui-gql-client    = { version = "0.16", public = true, default-features = false, optional = true, path = "../sui-gql-client" }
+sui-sdk-types     = { version = "0.0.3", public = true }
+# TODO: remove this after using Rust's `Option` (see TODO in `lib.rs`)
+move-stdlib-sdk = { version = "0.10.8", public = true, path = "../move-stdlib-sdk" }
+
+af-move-type = { version = "0.9.7", path = "../af-move-type" }
+af-sui-types = { version = "0.8.7", path = "../af-sui-types" }
 
 clap        = { version = "4", features = ["derive"] }
 derive_more = { version = "2", features = ["display", "from", "is_variant", "try_into"] }
 num-traits  = "0.2"
-num_enum    = "0.7"
 remain      = "0.2"
 serde       = "1"
-strum       = { version = "0.27", features = ["derive"] }
 thiserror   = "2"
 
 # GraphQL RPC (optional)
@@ -62,7 +69,6 @@ cynic           = { version = "3", optional = true }
 enum-as-inner   = { version = "0.6", optional = true }
 futures         = { version = "0.3", optional = true }
 graphql-extract = { version = "0.0.7", path = "../graphql-extract", optional = true }
-sui-gql-client  = { version = "0.16", path = "../sui-gql-client", default-features = false, optional = true }
 
 # SLO
 bcs        = { version = "0.1", optional = true }
@@ -73,7 +79,7 @@ default-features = false
 features         = ["build"]
 optional         = true
 path             = "../sui-gql-schema"
-version = "0.10.7"
+version          = "0.10.7"
 
 
 [dev-dependencies]

--- a/crates/af-iperps/src/lib.rs
+++ b/crates/af-iperps/src/lib.rs
@@ -136,6 +136,7 @@ sui_pkg_sdk!(perpetuals {
             min_margin_before: IFixed,
             fills: vector<orderbook::FillReceipt>,
             post: orderbook::PostReceipt,
+            // TODO: Rust's `Option` is perfectly fine here
             liquidation_receipt: move_stdlib_sdk::option::Option<LiquidationReceipt>
         }
 

--- a/crates/af-keys/Cargo.toml
+++ b/crates/af-keys/Cargo.toml
@@ -25,21 +25,31 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-sui-types  = { version = "0.8.7", public = true, features = ["hash"], path = "../af-sui-types" }
+eyre          = { version = "0.6", public = true }
+fastcrypto    = { version = "0.1.9", public = true }
+serde         = { version = "1", public = true }
+signature     = { version = "2", public = true }
+sui-sdk-types = { version = "0.0.3", public = true }
+## Because of `fastcrypto`
+blake2  = { version = "0.10", public = true }
+digest  = { version = "0.10", public = true }
+typenum = { version = "1", public = true }
+
 bcs           = "0.1"
 derive_more   = { version = "2", features = ["as_ref", "from"] }
 enum_dispatch = "0.3"
-eyre          = "0.6"
-fastcrypto    = "0.1.9"
 once_cell     = "1"
-serde         = "1"
+rustversion   = "1"
 serde_json    = "1"
 serde_repr    = "0.1"
 serde_with    = "3"
-signature     = "2"
 strum         = { version = "0.27", features = ["derive"] }
 thiserror     = "2"
 
-af-sui-types = { version = "0.8.7", features = ["hash"], path = "../af-sui-types" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/af-keys/src/multisig.rs
+++ b/crates/af-keys/src/multisig.rs
@@ -121,9 +121,12 @@ impl MultiSig {
         &self.multisig_pk
     }
 
-    #[expect(
-        clippy::missing_const_for_fn,
-        reason = "Not changing the public API right now"
+    #[rustversion::attr(
+        stable,
+        expect(
+            clippy::missing_const_for_fn,
+            reason = "Not changing the public API right now"
+        )
     )]
     pub fn get_sigs(&self) -> &[CompressedSignature] {
         &self.sigs
@@ -253,7 +256,7 @@ impl MultiSigPublicKey {
             || threshold == 0
             || pks.len() != weights.len()
             || pks.len() > MAX_SIGNER_IN_MULTISIG
-            || weights.iter().any(|w| *w == 0)
+            || weights.contains(&0)
             || weights
                 .iter()
                 .map(|w| *w as ThresholdUnit)

--- a/crates/af-move-type-derive/Cargo.toml
+++ b/crates/af-move-type-derive/Cargo.toml
@@ -29,11 +29,13 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
+proc-macro2 = { version = "1.0.70", public = true }
+syn         = { version = "2.0.39", public = true, features = ["full"] }
+
 convert_case = "0.7.1"
 deluxe       = "0.5.0"
-proc-macro2  = "1.0.70"
 quote        = "1.0.33"
-syn          = { version = "2.0.39", features = ["full"] }
+rustversion  = "1"
 
 [dev-dependencies]
 af-move-type = { path = "../af-move-type" }

--- a/crates/af-move-type-derive/src/move_struct.rs
+++ b/crates/af-move-type-derive/src/move_struct.rs
@@ -15,6 +15,7 @@ struct MoveAttributes {
     nameless: bool,
 }
 
+#[rustversion::attr(nightly, expect(clippy::obfuscated_if_else))]
 pub fn impl_move_struct(item: TokenStream) -> deluxe::Result<TokenStream> {
     // parse
     let mut ast: DeriveInput = syn::parse2(item)?;

--- a/crates/af-move-type/Cargo.toml
+++ b/crates/af-move-type/Cargo.toml
@@ -25,14 +25,18 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-af-move-type-derive = { version = "0.3", path = "../af-move-type-derive" }
-af-sui-types        = { version = "0.8.7", path = "../af-sui-types", features = ["u256"] }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-sui-types = { version = "0.8.7", public = true, features = ["u256"], path = "../af-sui-types" }
+bcs          = { version = "0.1", public = true }
+serde_json   = { version = "1", public = true }
 
-bcs           = "0.1"
+af-move-type-derive = { version = "0.3", path = "../af-move-type-derive" }
+
 derive-where  = "1"
 derive_more   = { version = "2", features = ["deref", "deref_mut", "from", "into"] }
 serde         = "1"
-serde_json    = "1"
 serde_with    = "3"
 sui-sdk-types = "0.0.3"
 tabled        = "0.16"

--- a/crates/af-oracle/Cargo.toml
+++ b/crates/af-oracle/Cargo.toml
@@ -41,12 +41,19 @@ graphql = [
   "sui-gql-schema/build",
 ]
 
+
 [dependencies]
-af-move-type      = { version = "0.9.7", path = "../af-move-type" }
-af-sui-pkg-sdk    = { version = "0.9.8", path = "../af-sui-pkg-sdk" }
-af-sui-types      = { version = "0.8.7", path = "../af-sui-types" }
-af-utilities      = { version = "0.9.7", path = "../af-utilities" }
-sui-framework-sdk = { version = "0.11.9", path = "../sui-framework-sdk" }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-move-type      = { version = "0.9.7", public = true, path = "../af-move-type" }
+af-sui-pkg-sdk    = { version = "0.9.8", public = true, path = "../af-sui-pkg-sdk" }
+sui-framework-sdk = { version = "0.11.9", public = true, path = "../sui-framework-sdk" }
+sui-gql-client    = { version = "0.16.9", public = true, optional = true, default-features = false, path = "../sui-gql-client" }
+sui-sdk-types     = { version = "0.0.3", public = true }
+
+af-sui-types = { version = "0.8.7", path = "../af-sui-types" }
+af-utilities = { version = "0.9.7", path = "../af-utilities" }
 
 derive_more = { version = "2", features = ["display", "from", "is_variant", "try_into"] }
 remain      = "0.2"
@@ -65,19 +72,14 @@ enum-as-inner   = { version = "0.6", optional = true }
 futures         = { version = "0.3", optional = true }
 graphql-extract = { version = "0.0.7", path = "../graphql-extract", optional = true }
 
-[dependencies.sui-gql-client]
-default-features = false
-features         = ["move-type", "queries"]
-optional         = true
-path             = "../sui-gql-client"
-version = "0.16.9"
 
 [build-dependencies.sui-gql-schema]
 default-features = false
 features         = ["build"]
 optional         = true
 path             = "../sui-gql-schema"
-version = "0.10.7"
+version          = "0.10.7"
+
 
 [dev-dependencies]
 clap             = { version = "4", features = ["derive"] }

--- a/crates/af-ptbuilder/Cargo.toml
+++ b/crates/af-ptbuilder/Cargo.toml
@@ -25,13 +25,16 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-bcs           = "0.1"
-indexmap      = "2"
-serde         = { version = "1", features = ["derive"] }
-sui-sdk-types = "0.0.3"
-thiserror     = "2"
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-sui-types  = { version = "0.8.7", public = true, path = "../af-sui-types" }
+bcs           = { version = "0.1", public = true }
+serde         = { version = "1", public = true, features = ["derive"] }
+sui-sdk-types = { version = "0.0.3", public = true }
 
-af-sui-types = { version = "0.8.7", path = "../af-sui-types" }
+indexmap  = "2"
+thiserror = "2"
 
 
 [dev-dependencies]

--- a/crates/af-pyth-wrapper/Cargo.toml
+++ b/crates/af-pyth-wrapper/Cargo.toml
@@ -30,36 +30,27 @@ graphql = [
   "dep:af-sui-types",
   "dep:bcs",
   "dep:extension-traits",
-  "dep:sui-gql-client",
   "dep:thiserror",
   "dep:trait-variant",
+  "sui-gql-client/move-type",
+  "sui-gql-client/queries",
 ]
 ptb = ["dep:af-ptbuilder", "dep:extension-traits"]
 
 [dependencies]
-af-sui-pkg-sdk    = { version = "0.9.8", path = "../af-sui-pkg-sdk" }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-ptbuilder   = { version = "5.0.7", public = true, optional = true, path = "../af-ptbuilder" }
+af-sui-pkg-sdk = { version = "0.9.8", public = true, path = "../af-sui-pkg-sdk" }
+sui-gql-client = { version = "0.16.9", public = true, optional = true, default-features = false, path = "../sui-gql-client" }
+sui-sdk-types  = { version = "0.0.3", public = true }
+
 sui-framework-sdk = { version = "0.11.9", path = "../sui-framework-sdk" }
 
+af-move-type     = { version = "0.9.7", optional = true, path = "../af-move-type" }
+af-sui-types     = { version = "0.8.7", optional = true, path = "../af-sui-types" }
 bcs              = { version = "0.1", optional = true }
 extension-traits = { version = "2", optional = true }
 thiserror        = { version = "2", optional = true }
 trait-variant    = { version = "0.1", optional = true }
-
-[dependencies.af-ptbuilder]
-optional = true
-path     = "../af-ptbuilder"
-version = "5.0.7"
-[dependencies.af-sui-types]
-optional = true
-path     = "../af-sui-types"
-version = "0.8.7"
-[dependencies.af-move-type]
-optional = true
-path     = "../af-move-type"
-version = "0.9.7"
-[dependencies.sui-gql-client]
-default-features = false
-features         = ["move-type", "queries"]
-optional         = true
-path             = "../sui-gql-client"
-version = "0.16.9"

--- a/crates/af-sui-pkg-sdk/Cargo.toml
+++ b/crates/af-sui-pkg-sdk/Cargo.toml
@@ -26,12 +26,17 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-af-move-type = { version = "0.9.7", path = "../af-move-type" }
-af-sui-types = { version = "0.8.7", path = "../af-sui-types", features = ["u256"] }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-move-type = { version = "0.9.7", public = true, path = "../af-move-type" }
+af-sui-types = { version = "0.8.7", public = true, features = ["u256"], path = "../af-sui-types" }
+tabled       = { version = "0.16", public = true }
+# Because of `tabled`
+papergrid = { version = "0.12", public = true }
 
 derive-new = "0.7.0"
 serde      = "1"
-tabled     = "0.16"
 
 [dev-dependencies]
 anyhow      = "1"

--- a/crates/af-sui-pkg-sdk/README.md
+++ b/crates/af-sui-pkg-sdk/README.md
@@ -120,3 +120,19 @@ access the type of the OTW directly, while to do so with the latter we'd have to
 `StructTag::type_params` is not empty every time.
 
 <!-- cargo-rdme end -->
+
+## Future plans & refactors
+
+### Make `tabled` a private dependency
+
+Currently, `tabled` is a [public dependency] because the macro implements the `Tabled` trait for the generated public structs. The only reason that implementation is there, however, is to leverage it in the `Display` implementations for generated structs.
+
+Therefore, it's possible to remove `tabled` from the public API altogether by:
+1. making the `pub use tabled;` re-export `#[doc(hidden)]`
+1. generating a private `mod $Struct { pub(super) struct DisplayRef<'a> { /* ... */ } }` for each Move struct
+1. implementing `tabled::Tabled` for the private struct
+1. implementing `Display` for the public struct by constructing `DisplayRef<'_>` internally and using its `Tabled` implementation
+1. removing the `move_struct_table_option` function (inline it in the generated code)
+
+
+[public dependency]: https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html

--- a/crates/af-sui-types/Cargo.toml
+++ b/crates/af-sui-types/Cargo.toml
@@ -30,26 +30,28 @@ hash    = ["sui-sdk-types/hash"]
 u256    = ["dep:primitive-types", "dep:rand", "dep:uint"]
 
 [dependencies]
-base64        = "0.22"
-bcs           = "0.1"
-bs58          = "0.5"
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+base64        = { version = "0.22", public = true }
+bcs           = { version = "0.1", public = true }
+bs58          = { version = "0.5", public = true }
+proptest      = { version = "1", public = true, optional = true }
+rand          = { version = "0.9", public = true, optional = true }
+serde         = { version = "1", public = true }
+serde_with    = { version = "3", public = true, features = ["base64"] }
+sui-sdk-types = { version = "0.0.3", public = true, features = ["serde"] }
+
 enum_dispatch = "0.3"
 hex           = "0.4"
 ref-cast      = "1"
-serde         = "1"
-serde_with    = { version = "3", features = ["base64"] }
-sui-sdk-types = { version = "0.0.3", features = ["serde"] }
 thiserror     = "2"
 
 derive_more = { version = "2", features = ["from_str"] }
 
-# for u256 (optional)
+# for u256
 primitive-types = { version = "0.12", features = ["fp-conversion"], optional = true }
-rand            = { version = "0.9", optional = true }
 uint            = { version = "0.9", optional = true }
-
-# for fuzzing tests (optional)
-proptest = { version = "1", optional = true }
 
 [dev-dependencies]
 insta         = "1"

--- a/crates/af-switchboard-wrapper/Cargo.toml
+++ b/crates/af-switchboard-wrapper/Cargo.toml
@@ -30,36 +30,27 @@ graphql = [
   "dep:af-sui-types",
   "dep:bcs",
   "dep:extension-traits",
-  "dep:sui-gql-client",
   "dep:thiserror",
   "dep:trait-variant",
+  "sui-gql-client/move-type",
+  "sui-gql-client/queries",
 ]
 ptb = ["dep:af-ptbuilder", "dep:extension-traits"]
 
 [dependencies]
-af-sui-pkg-sdk    = { version = "0.9.8", path = "../af-sui-pkg-sdk" }
-sui-framework-sdk = { version = "0.11.9", path = "../sui-framework-sdk" }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-ptbuilder      = { version = "5.0.7", public = true, optional = true, path = "../af-ptbuilder" }
+af-sui-pkg-sdk    = { version = "0.9.8", public = true, path = "../af-sui-pkg-sdk" }
+sui-framework-sdk = { version = "0.11.9", public = true, path = "../sui-framework-sdk" }
+sui-gql-client    = { version = "0.16.9", public = true, default-features = false, optional = true, path = "../sui-gql-client" }
+sui-sdk-types     = { version = "0.0.3", public = true }
 
 bcs              = { version = "0.1", optional = true }
 extension-traits = { version = "2", optional = true }
 thiserror        = { version = "2", optional = true }
 trait-variant    = { version = "0.1", optional = true }
 
-[dependencies.af-ptbuilder]
-optional = true
-path     = "../af-ptbuilder"
-version = "5.0.7"
-[dependencies.af-sui-types]
-optional = true
-path     = "../af-sui-types"
-version = "0.8.7"
-[dependencies.af-move-type]
-optional = true
-path     = "../af-move-type"
-version = "0.9.7"
-[dependencies.sui-gql-client]
-default-features = false
-features         = ["move-type", "queries"]
-optional         = true
-path             = "../sui-gql-client"
-version = "0.16.9"
+af-move-type = { version = "0.9.7", optional = true, path = "../af-move-type" }
+af-sui-types = { version = "0.8.7", optional = true, path = "../af-sui-types" }

--- a/crates/af-switchboard-wrapper/src/lib.rs
+++ b/crates/af-switchboard-wrapper/src/lib.rs
@@ -3,7 +3,7 @@
 //! Move types for Aftermath's `SwitchboardWrapper` package that extends `AfOracle`
 
 use af_sui_pkg_sdk::sui_pkg_sdk;
-use sui_framework_sdk::object::UID;
+use sui_framework_sdk::UID;
 
 #[cfg(feature = "graphql")]
 pub mod graphql;

--- a/crates/af-utilities/Cargo.toml
+++ b/crates/af-utilities/Cargo.toml
@@ -25,11 +25,14 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-af-sui-types = { version = "0.8.7", path = "../af-sui-types", features = ["u256"] }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-sui-types = { version = "0.8.7", public = true, features = ["u256"], path = "../af-sui-types" }
+num-traits   = { version = "0.2", public = true }
 
-num-traits = "0.2"
-serde      = "1"
-thiserror  = "2"
+serde     = "1"
+thiserror = "2"
 
 [[example]]
 name = "utilities_types"

--- a/crates/move-stdlib-sdk/Cargo.toml
+++ b/crates/move-stdlib-sdk/Cargo.toml
@@ -25,6 +25,9 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-af-sui-pkg-sdk = { version = "0.9.8", path = "../af-sui-pkg-sdk" }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-sui-pkg-sdk = { version = "0.9.8", public = true, path = "../af-sui-pkg-sdk" }
 
 thiserror = "2"

--- a/crates/pyth-hermes-client/Cargo.toml
+++ b/crates/pyth-hermes-client/Cargo.toml
@@ -22,25 +22,35 @@ rustdoc-args = [
 ]
 
 [features]
-default    = ["rustls-tls"]
+default = ["rustls-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
-stream     = ["dep:eventsource-stream", "dep:futures", "dep:serde_json", "reqwest/stream"]
+stream = [
+  "dep:eventsource-stream",
+  "dep:futures-core",
+  "dep:futures-util",
+  "dep:serde_json",
+  "reqwest/stream",
+]
 
 [dependencies]
-base64   = "0.22"
-hex      = "0.4"
-pyth-sdk = "0.8"
-# reqwest            = { version = "0.12", default-features = false, features = ["json", "stream"] }
-reqwest   = { version = "0.12", default-features = false, features = ["json"] }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+base64             = { version = "0.22", public = true }
+eventsource-stream = { version = "0.2", public = true, optional = true }
+futures-core       = { version = "0.3", public = true, optional = true }
+hex                = { version = "0.4", public = true }
+pyth-sdk           = { version = "0.8", public = true }
+reqwest            = { version = "0.12", public = true, default-features = false, features = ["json"] }
+serde_json         = { version = "1", public = true, optional = true }
+url                = { version = "2", public = true }
+
 serde     = { version = "1", features = ["derive"] }
 strum     = { version = "0.27", features = ["derive"] }
 thiserror = "2"
-url       = "2"
 
-eventsource-stream = { version = "0.2", optional = true }
-futures            = { version = "0.3", optional = true }
-serde_json         = { version = "1", optional = true }
+futures-util = { version = "0.3", optional = true }
 
 [dev-dependencies]
 clap       = { version = "4", features = ["derive"] }

--- a/crates/pyth-hermes-client/examples/price_update_stream.rs
+++ b/crates/pyth-hermes-client/examples/price_update_stream.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use futures::{StreamExt as _, TryStreamExt as _};
+use futures_util::{StreamExt as _, TryStreamExt as _};
 use pyth_hermes_client::{EncodingType, PriceIdInput, PythClient};
 
 #[derive(Parser)]

--- a/crates/pyth-hermes-client/src/stream.rs
+++ b/crates/pyth-hermes-client/src/stream.rs
@@ -1,5 +1,5 @@
 use eventsource_stream::Eventsource as _;
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures_util::{Stream, StreamExt, TryStreamExt};
 use serde::Serialize;
 
 use crate::{EncodingType, Error, PriceIdInput, PriceUpdate};

--- a/crates/pyth-sui-sdk/Cargo.toml
+++ b/crates/pyth-sui-sdk/Cargo.toml
@@ -25,28 +25,34 @@ rustdoc-args = [
 workspace = true
 
 [features]
-json-rpc = ["dep:af-ptbuilder", "dep:sui-jsonrpc", "sui-jsonrpc/client-api"]
+json-rpc = ["dep:af-ptbuilder", "dep:jsonrpsee-core", "dep:sui-jsonrpc", "sui-jsonrpc/client-api"]
 ptb      = ["bytes/serde", "dep:af-ptbuilder", "dep:bytes", "dep:extension-traits"]
 pyth-sdk = ["dep:af-utilities", "dep:pyth-sdk"]
 
 [dependencies]
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-ptbuilder   = { version = "5.0.7", public = true, optional = true, path = "../af-ptbuilder" }
+af-sui-types   = { version = "0.8.7", public = true, path = "../af-sui-types" }
+af-utilities   = { version = "0.9", public = true, optional = true }
+bcs            = { version = "0.1", public = true }
+bytes          = { version = "1", public = true, optional = true }
+hex            = { version = "0.4.3", public = true }
+jsonrpsee-core = { version = "0.24", public = true, optional = true }
+pyth-sdk       = { version = "0.8", public = true, optional = true }
+sui-jsonrpc    = { version = "0.15.2", public = true, default-features = false, optional = true, path = "../sui-jsonrpc" }
+sui-sdk-types  = { version = "0.0.3", public = true }
+
 af-move-type      = { version = "0.9.7", path = "../af-move-type" }
 af-sui-pkg-sdk    = { version = "0.9.8", path = "../af-sui-pkg-sdk" }
-af-sui-types      = { version = "0.8.7", path = "../af-sui-types" }
 sui-framework-sdk = { version = "0.11.9", path = "../sui-framework-sdk" }
 wormhole-sui-sdk  = { version = "0.11.9", path = "../wormhole-sui-sdk" }
 
-bcs       = "0.1"
-hex       = "0.4.3"
 serde     = "1"
 thiserror = "2"
 
 # Optional deps
-af-utilities     = { version = "0.9", optional = true }
-bytes            = { version = "1", optional = true }
 extension-traits = { version = "2", optional = true }
-pyth-sdk         = { version = "0.8", optional = true }
 
 # Optional aftermath deps
-af-ptbuilder = { version = "5.0.7", optional = true, path = "../af-ptbuilder" }
-sui-jsonrpc  = { version = "0.15.2", path = "../sui-jsonrpc", default-features = false, optional = true }

--- a/crates/sui-framework-sdk/Cargo.toml
+++ b/crates/sui-framework-sdk/Cargo.toml
@@ -25,18 +25,15 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-af-move-type    = { version = "0.9.7", path = "../af-move-type" }
-af-sui-pkg-sdk  = { version = "0.9.8", path = "../af-sui-pkg-sdk" }
-af-sui-types    = { version = "0.8.7", path = "../af-sui-types" }
-move-stdlib-sdk = { version = "0.10.8", path = "../move-stdlib-sdk" }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-move-type    = { version = "0.9.7", public = true, path = "../af-move-type" }
+af-sui-pkg-sdk  = { version = "0.9.8", public = true, path = "../af-sui-pkg-sdk" }
+af-sui-types    = { version = "0.8.7", public = true, path = "../af-sui-types" }
+move-stdlib-sdk = { version = "0.10.8", public = true, path = "../move-stdlib-sdk" }
 
-derive-new  = "0.7"
 derive_more = { version = "2", features = ["from"] }
-hex         = "0.4"
-serde       = "1"
-serde_with  = "3"
-thiserror   = "2"
-tracing     = "0.1"
 
 
 [dev-dependencies]

--- a/crates/sui-gql-client/Cargo.toml
+++ b/crates/sui-gql-client/Cargo.toml
@@ -27,11 +27,13 @@ workspace = true
 [features]
 default = ["move-type", "mutations", "queries", "reqwest"]
 move-type = ["dep:af-move-type", "dep:bcs", "queries"]
-mutations = ["dep:af-sui-types", "scalars"]
+mutations = ["dep:af-sui-types", "dep:sui-sdk-types", "scalars"]
 queries = [
   "dep:af-sui-types",
   "dep:async-stream",
+  "dep:bimap",
   "dep:futures",
+  "dep:futures-core",
   "dep:graphql-extract",
   "dep:itertools",
   "scalars",
@@ -42,15 +44,27 @@ scalars = ["sui-gql-schema/scalars"]
 
 
 [dependencies]
-graphql-extract = { version = "0.0.7", path = "../graphql-extract", optional = true }
-sui-gql-schema  = { version = "0.10.7", path = "../sui-gql-schema", default-features = false }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+# FIXME: this is in dire need of refactoring; see
+# https://github.com/AftermathFinance/aftermath-sdk-rust/issues/181
+af-move-type   = { version = "0.9.7", public = true, optional = true, path = "../af-move-type" }
+af-sui-types   = { version = "0.8.7", public = true, path = "../af-sui-types", optional = true }
+bimap          = { version = "0.6", public = true, optional = true }
+cynic          = { version = "3", public = true }
+futures-core   = { version = "0.3", public = true, optional = true }
+reqwest        = { version = "0.12", public = true, default-features = false, optional = true }
+serde          = { version = "1", public = true }
+serde_json     = { version = "1", public = true, optional = true }
+sui-gql-schema = { version = "0.10.7", public = true, default-features = false, path = "../sui-gql-schema" }
+sui-sdk-types  = { version = "0.0.3", public = true, optional = true }
 
-bimap            = "0.6"
+graphql-extract = { version = "0.0.7", path = "../graphql-extract", optional = true }
+
 clap             = { version = "4", features = ["derive"] }
-cynic            = "3"
 derive_more      = { version = "2", features = ["display"] }
 extension-traits = "2"
-serde            = "1"
 tap              = "1"
 thiserror        = "2"
 trait-variant    = "0.1"
@@ -59,25 +73,18 @@ trait-variant    = "0.1"
 async-stream = { version = "0.3", optional = true }
 futures      = { version = "0.3", optional = true }
 
-# Reqwest client (optional)
-reqwest = { version = "0.12", default-features = false, optional = true }
-
 # For pre-made queries (optional)
-af-sui-types = { version = "0.8.7", path = "../af-sui-types", optional = true }
-itertools    = { version = "0.14", optional = true }
+itertools = { version = "0.14", optional = true }
 
 # MoveType compat (optional)
-af-move-type = { version = "0.9.7", path = "../af-move-type", optional = true }
-bcs          = { version = "0.1", optional = true }
+bcs = { version = "0.1", optional = true }
 
-# Raw client (optional)
-serde_json = { version = "1", optional = true }
 
 [build-dependencies.sui-gql-schema]
 default-features = false
 features         = ["build"]
 path             = "../sui-gql-schema"
-version = "0.10.7"
+version          = "0.10.7"
 
 
 [dev-dependencies]

--- a/crates/sui-gql-schema/Cargo.toml
+++ b/crates/sui-gql-schema/Cargo.toml
@@ -40,15 +40,18 @@ scalars = [
 
 
 [dependencies]
-cynic = "3"
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-sui-types = { version = "0.8.7", public = true, optional = true, path = "../af-sui-types" }
+cynic        = { version = "3", public = true }
 
 # For scalars (optional)
-af-sui-types = { version = "0.8.7", path = "../af-sui-types", optional = true }
-base64       = { version = "0.22", optional = true }
-chrono       = { version = "0.4", optional = true }
-serde        = { version = "1", optional = true }
-serde_json   = { version = "1", optional = true }
-serde_with   = { version = "3", optional = true }
+base64     = { version = "0.22", optional = true }
+chrono     = { version = "0.4", optional = true }
+serde      = { version = "1", optional = true }
+serde_json = { version = "1", optional = true }
+serde_with = { version = "3", optional = true }
 
 derive_more = { version = "2", features = [
   "as_ref",

--- a/crates/sui-jsonrpc/Cargo.toml
+++ b/crates/sui-jsonrpc/Cargo.toml
@@ -31,15 +31,31 @@ client = [
   "dep:futures-core",
   "dep:futures-util",
   "dep:http",
-  "dep:jsonrpsee",
-  "jsonrpsee/http-client",
+  "dep:jsonrpsee-http-client",
   "jsonrpsee/ws-client",
 ]
-client-api = ["dep:extension-traits", "jsonrpsee/client-core", "jsonrpsee/macros"]
+client-api = [
+  "dep:extension-traits",
+  "dep:jsonrpsee-core",
+  "dep:jsonrpsee-types",
+  "jsonrpsee/client-core",
+  "jsonrpsee/macros",
+]
 default = ["client"]
 
 [dependencies]
-af-sui-types  = { version = "0.8.7", path = "../af-sui-types" }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-sui-types          = { version = "0.8.7", public = true, path = "../af-sui-types" }
+futures-core          = { version = "0.3", public = true, optional = true }
+jsonrpsee-core        = { version = "0.24", public = true, optional = true }
+jsonrpsee-http-client = { version = "0.24", public = true, optional = true }
+jsonrpsee-types       = { version = "0.24", public = true, optional = true }
+serde                 = { version = "1", public = true }
+serde_json            = { version = "1", public = true }
+sui-sdk-types         = { version = "0.0.3", public = true }
+
 bcs           = "0.1"
 colored       = "3"
 derive_more   = { version = "2", features = ["from"] }
@@ -47,19 +63,16 @@ enum_dispatch = "0.3"
 itertools     = "0.14"
 json_to_table = "0.6"
 regex         = "1"
-serde         = "1"
-serde_json    = "1"
 serde_with    = "3"
-sui-sdk-types = "0.0.3"
 tabled        = "0.12"
 thiserror     = "2"
 
 async-stream     = { version = "0.3", optional = true }
 extension-traits = { version = "2", optional = true }
-futures-core     = { version = "0.3", optional = true }
 futures-util     = { version = "0.3", optional = true }
 http             = { version = "1", optional = true }
 jsonrpsee        = { version = "0.24", optional = true }
+rustversion      = "1"
 
 [dev-dependencies]
 color-eyre = "0.6"

--- a/crates/sui-jsonrpc/src/client.rs
+++ b/crates/sui-jsonrpc/src/client.rs
@@ -22,9 +22,9 @@ use af_sui_types::{
 };
 use futures_core::Stream;
 use jsonrpsee::core::client::ClientT;
-use jsonrpsee::http_client::{HeaderMap, HeaderValue, HttpClient, HttpClientBuilder};
 use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::{PingConfig, WsClient, WsClientBuilder};
+use jsonrpsee_http_client::{HeaderMap, HeaderValue, HttpClient, HttpClientBuilder};
 use serde_json::Value;
 
 use super::{CLIENT_SDK_TYPE_HEADER, CLIENT_SDK_VERSION_HEADER, CLIENT_TARGET_API_VERSION_HEADER};
@@ -319,18 +319,24 @@ impl SuiClient {
     }
 
     /// Returns a list of RPC methods supported by the node the client is connected to.
-    #[expect(
-        clippy::missing_const_for_fn,
-        reason = "Not changing the public API right now"
+    #[rustversion::attr(
+        stable,
+        expect(
+            clippy::missing_const_for_fn,
+            reason = "Not changing the public API right now"
+        )
     )]
     pub fn available_rpc_methods(&self) -> &Vec<String> {
         &self.info.rpc_methods
     }
 
     /// Returns a list of streaming/subscription APIs supported by the node the client is connected to.
-    #[expect(
-        clippy::missing_const_for_fn,
-        reason = "Not changing the public API right now"
+    #[rustversion::attr(
+        stable,
+        expect(
+            clippy::missing_const_for_fn,
+            reason = "Not changing the public API right now"
+        )
     )]
     pub fn available_subscriptions(&self) -> &Vec<String> {
         &self.info.subscriptions
@@ -340,9 +346,12 @@ impl SuiClient {
     ///
     /// The format of this string is `<major>.<minor>.<patch>`, e.g., `1.6.0`,
     /// and it is retrieved from the OpenRPC specification via the discover service method.
-    #[expect(
-        clippy::missing_const_for_fn,
-        reason = "Not changing the public API right now"
+    #[rustversion::attr(
+        stable,
+        expect(
+            clippy::missing_const_for_fn,
+            reason = "Not changing the public API right now"
+        )
     )]
     pub fn api_version(&self) -> &str {
         &self.info.version
@@ -362,18 +371,24 @@ impl SuiClient {
     }
 
     /// Returns a reference to the underlying http client.
-    #[expect(
-        clippy::missing_const_for_fn,
-        reason = "Not changing the public API right now"
+    #[rustversion::attr(
+        stable,
+        expect(
+            clippy::missing_const_for_fn,
+            reason = "Not changing the public API right now"
+        )
     )]
     pub fn http(&self) -> &HttpClient {
         &self.http
     }
 
     /// Returns a reference to the underlying WebSocket client, if any.
-    #[expect(
-        clippy::missing_const_for_fn,
-        reason = "Not changing the public API right now"
+    #[rustversion::attr(
+        stable,
+        expect(
+            clippy::missing_const_for_fn,
+            reason = "Not changing the public API right now"
+        )
     )]
     pub fn ws(&self) -> Option<&WsClient> {
         (*self.ws).as_ref()

--- a/crates/sui-jsonrpc/src/error.rs
+++ b/crates/sui-jsonrpc/src/error.rs
@@ -2,8 +2,8 @@ use std::sync::LazyLock;
 
 use af_sui_types::ObjectId;
 use extension_traits::extension;
-use jsonrpsee::core::ClientError;
-use jsonrpsee::types::{ErrorCode, ErrorObject, ErrorObjectOwned};
+use jsonrpsee_core::ClientError;
+use jsonrpsee_types::{ErrorCode, ErrorObject, ErrorObjectOwned};
 
 pub type JsonRpcClientResult<T = ()> = Result<T, JsonRpcClientError>;
 

--- a/crates/sui-jsonrpc/src/msgs/sui_object.rs
+++ b/crates/sui-jsonrpc/src/msgs/sui_object.rs
@@ -342,6 +342,7 @@ impl SuiObjectData {
         Ok(ObjectArg::ImmOrOwnedObject((i, v, d)))
     }
 
+    #[cfg(feature = "client")]
     pub(crate) fn object_arg(&self, mutable: bool) -> Result<ObjectArg, SuiObjectDataError> {
         use Owner as O;
         Ok(match self.owner()? {
@@ -886,6 +887,7 @@ pub enum SuiPastObjectResponseError {
     ObjectDeleted { object_ref: ObjectRef },
 }
 
+#[rustversion::attr(nightly, expect(clippy::large_enum_variant))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "status", content = "details", rename = "ObjectRead")]
 pub enum SuiPastObjectResponse {

--- a/crates/switchboard-sui-sdk/Cargo.toml
+++ b/crates/switchboard-sui-sdk/Cargo.toml
@@ -28,11 +28,17 @@ workspace = true
 ptb = ["bytes/serde", "dep:af-ptbuilder", "dep:bytes", "dep:extension-traits"]
 
 [dependencies]
-af-move-type      = { version = "0.9.7", path = "../af-move-type" }
-af-sui-pkg-sdk    = { version = "0.9.8", path = "../af-sui-pkg-sdk" }
-af-sui-types      = { version = "0.8.7", path = "../af-sui-types" }
-move-stdlib-sdk   = { version = "0.10.8", path = "../move-stdlib-sdk" }
-sui-framework-sdk = { version = "0.11.9", path = "../sui-framework-sdk" }
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-ptbuilder      = { version = "5.0.7", public = true, optional = true, path = "../af-ptbuilder" }
+af-sui-pkg-sdk    = { version = "0.9.8", public = true, path = "../af-sui-pkg-sdk" }
+move-stdlib-sdk   = { version = "0.10.8", public = true, path = "../move-stdlib-sdk" }
+sui-framework-sdk = { version = "0.11.9", public = true, path = "../sui-framework-sdk" }
+sui-sdk-types     = { version = "0.0.3", public = true }
+
+af-move-type = { version = "0.9.7", path = "../af-move-type" }
+af-sui-types = { version = "0.8.7", path = "../af-sui-types" }
 
 bcs       = "0.1"
 hex       = "0.4.3"
@@ -42,6 +48,3 @@ thiserror = "2"
 # Optional deps
 bytes            = { version = "1", optional = true }
 extension-traits = { version = "2", optional = true }
-
-# Optional aftermath deps
-af-ptbuilder = { version = "5.0.7", optional = true, path = "../af-ptbuilder" }

--- a/crates/wormhole-sui-sdk/Cargo.toml
+++ b/crates/wormhole-sui-sdk/Cargo.toml
@@ -25,8 +25,8 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-af-sui-pkg-sdk    = { version = "0.9.8", path = "../af-sui-pkg-sdk" }
-af-sui-types      = { version = "0.8.7", path = "../af-sui-types" }
-sui-framework-sdk = { version = "0.11.9", path = "../sui-framework-sdk" }
-
-serde = "1"
+# Public dependencies; a SemVer-breaking bump in one of these must come with a SemVer-breaking bump
+# to this crate
+# https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
+af-sui-pkg-sdk    = { version = "0.9.8", public = true, path = "../af-sui-pkg-sdk" }
+sui-framework-sdk = { version = "0.11.9", public = true, path = "../sui-framework-sdk" }


### PR DESCRIPTION
This leverages [RFC 3516] to mark dependencies as public if that's the
case.

It makes the job of figuring out 'should I bump the major version of my
crate if I bumped the major version of dependency X' almost trivial.
This has been a fairly tedious and error-prone endeavour in the past, as
it required 'scanning' the public API of a crate every time a dependency
was updated to see if one of its items was exposed.

Its is accompanied by a [lint], enabled in `.cargo/config.toml`. Mind
you, it [isn't perfect], but goes a **long** way in avoiding a lot
common pitfalls.

I found this after doing more research on public dependencies since
managing them was one of the maintenance tasks I took on. Don't
underestimate this issue, as mishandling versioning in these scenarions
leads to compilation errors and lots of time wasted 'patching' crates.

[RFC 3516]: https://rust-lang.github.io/rfcs/3516-public-private-dependencies.html
[lint]: https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#exported-private-dependencies
[isn't perfect]: https://github.com/rust-lang/rust/issues/71043
